### PR TITLE
Add serverless-api-backend sample app

### DIFF
--- a/nodejs10.x/serverless-api-backend/.gitignore
+++ b/nodejs10.x/serverless-api-backend/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/nodejs10.x/serverless-api-backend/README.md
+++ b/nodejs10.x/serverless-api-backend/README.md
@@ -1,0 +1,191 @@
+# Website & Mobile Starter Project
+
+This project contains source code and supporting files for the serverless application that you created in the AWS Lambda console. You can update your application at any time by committing and pushing changes to your AWS CodeCommit or GitHub repository.
+
+This project includes the following files and folders:
+
+- src - Code for the application's Lambda function.
+- events - Invocation events that you can use to invoke the function.
+- \_\_tests__ - Unit tests for the application code.
+- template.yml - A SAM template that defines the application's AWS resources.
+- buildspec.yml -  A build specification file that tells AWS CodeBuild how to create a deployment package for the function.
+
+Your Lambda application includes two AWS CloudFormation stacks. The first stack creates the pipeline that builds and deploys your application.
+
+The pipeline creates a second stack that contains your application's resources, including Lambda functions, an API Gateway API, and Amazon DynamoDB tables. These resources are defined in the `template.yml` file in this project. You can update the template to add AWS resources through the same deployment process that updates your application code. You can view those resources in the **Resources** section of the application overview in the Lambda console.
+
+For a full list of possible operations, see the [AWS Lambda Applications documentation](https://docs.aws.amazon.com/lambda/latest/dg/deploying-lambda-apps.html).
+
+## Try the application out
+
+The sample application creates a RESTful API that takes HTTP requests and invokes Lambda functions. The API has POST and GET methods on the root path to create and list items. It has a GET method that takes an ID path parameter to retrieve items. Each method maps to one of the application's three Lambda functions.
+
+**To use the sample API**
+
+1. Choose your application from the [**Applications page**](https://console.aws.amazon.com/lambda/home#/applications) in the Lambda console. (Make sure you're in the right region)
+1. Copy the URL that's listed under **API endpoint**.
+1. At the command line, use cURL to send POST requests to the application endpoint.
+
+        $ ENDPOINT=<paste-your-endpoint-here>
+        $ curl -d '{"id":"1234ABCD", "name":"My item"}' -H "Content-Type: application/json" -X POST $ENDPOINT
+        {"id":"1234ABCD","name":"My item"}
+        $ curl -d '{"id":"2234ABCD", "name":"My other item"}' -H "Content-Type: application/json" -X POST $ENDPOINT
+        {"id":"2234ABCD","name":"My other item"}
+
+1. Send a GET request to the endpoint to get a list of items.
+
+        $ curl $ENDPOINT
+        [{"id":"1234ABCD","name":"My item"},{"id":"2234ABCD","name":"My other item"}]
+
+1. Send a GET request with the item ID to get a single item.
+
+        $ curl $ENDPOINT/1234ABCD
+        {"id":"1234ABCD","name":"My item"}
+
+To view the application's API, functions, and table, use the links in the **Resources** section of the application overview in the Lambda console.
+
+## Add a resource to your application
+
+The application template uses the AWS Serverless Application Model (AWS SAM) to define application resources. AWS SAM is an extension of AWS CloudFormation with a simpler syntax for configuring common serverless application resources, such as functions, triggers, and APIs. For resources that aren't included in the [AWS SAM specification](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md), you can use the standard [AWS CloudFormation resource types](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html).
+
+Update `template.yml` to add a dead-letter queue to your application. In the **Resources** section, add a resource named **MyQueue** with the type **AWS::SQS::Queue**.
+
+```
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+```
+
+The dead-letter queue is a location for Lambda to send events that could not be processed. It's only used if you invoke your function asynchronously, but it's useful here to show how you can modify your application's resources and function configuration.
+
+Commit the change and push.
+
+```bash
+my-application$ git commit -am "Add dead-letter queue."
+my-application$ git push
+```
+
+**To see how the pipeline processes and deploys the change**
+
+1. Open the [**Applications**](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Deployments**.
+
+When the deployment completes, view the application resources on the **Overview** tab to see the new resource.
+
+## Update the permissions boundary
+
+The sample application applies a **permissions boundary** to its function's execution role. The permissions boundary limits the permissions that you can add to the function's role. Without the boundary, users with write access to the project repository could modify the project template to give the function permission to access resources and services outside of the scope of the sample application.
+
+In order for the function to use the queue that you added in the previous step, you must extend the permissions boundary. The Lambda console detects resources that aren't in the permissions boundary and provides an updated policy that you can use to update it.
+
+**To update the application's permissions boundary**
+
+1. Open the [**Applications**](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Edit permissions boundary**.
+1. Follow the instructions shown to update the boundary to allow access to the new queue.
+
+## Update the function configuration
+
+Now you can grant the function permission to access the queue and configure the dead-letter queue setting.
+
+In the function's properties in `template.yml`, add the **DeadLetterQueue** configuration. Under Policies, add **SQSSendMessagePolicy**. **SQSSendMessagePolicy** is a [policy template](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-policy-templates.html) that grants the function permission to send messages to a queue.
+
+```
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+  getAllItemsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: src/handlers/get-all-items.getAllItemsHandler
+      Runtime: nodejs10.x
+      MemorySize: 128
+      Timeout: 60
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !GetAtt MyQueue.Arn
+      Policies:
+        - SQSSendMessagePolicy:
+            QueueName: !GetAtt MyQueue.QueueName
+        - DynamoDBCrudPolicy:
+            TableName: !Ref SampleTable
+```
+
+Commit and push the change. When the deployment completes, view the function in the console to see the updated configuration that specifies the dead-letter queue.
+
+## Build and test locally
+
+The AWS SAM command line interface (CLI) is an extension of the AWS CLI that adds functionality for building and testing Lambda applications. It uses Docker to run your functions in an Amazon Linux environment that matches Lambda. It can also emulate your application's build environment and API.
+
+If you prefer to use an integrated development environment (IDE) to build and test your application, you can use the AWS Toolkit.
+The AWS Toolkit is an open-source plugin for popular IDEs that uses the AWS SAM CLI to build and deploy serverless applications on AWS. The AWS Toolkit also adds step-through debugging for Lambda function code.
+
+To get started, see the following:
+
+* [PyCharm](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [IntelliJ](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [VS Code](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html)
+* [Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/welcome.html)
+
+To use the AWS SAM CLI with this sample, you need the following tools:
+
+* AWS CLI - [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) and [configure it with your AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
+* AWS SAM CLI - [Install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html).
+* Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community).
+
+Build your application with the `sam build` command.
+
+```bash
+my-application$ sam build -m package.json
+```
+
+The AWS SAM CLI installs dependencies that are defined in `package.json`, creates a deployment package, and saves its contents in the `.aws-sam/build` folder.
+
+Test a single function by invoking it directly with a test event. An event is a JSON document that represents the input that the function receives from the event source. Test events are included in the `events` folder in this project.
+
+Run functions locally and invoke them with the `sam local invoke` command.
+
+```bash
+my-application$ sam local invoke putItemFunction --event events/event-post-item.json
+my-application$ sam local invoke getAllItemsFunction --event events/event-get-all-items.json
+```
+
+The AWS SAM CLI can also emulate your application's API. Use the `sam local start-api` command to run the API locally on port 3000.
+
+```bash
+my-application$ sam local start-api
+my-application$ curl http://localhost:3000/
+```
+
+The AWS SAM CLI reads the application template to determine the API's routes and the functions that they invoke. The `Events` property on each function's definition includes the route and method for each path.
+
+```yaml
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /
+            Method: GET
+```
+
+## Unit tests
+
+Requirements:
+
+* Node.js - [Install Node.js 10](https://nodejs.org/en/), including the npm package management tool.
+
+Tests are defined in the \_\_tests__ folder in this project. Use `npm` to install the [Jest test framework](https://jestjs.io/) and run unit tests.
+
+```bash
+my-application$ npm install
+my-application$ npm run test
+```
+
+## Resources
+
+For an introduction to the AWS SAM specification, the AWS SAM CLI, and serverless application concepts, see the [AWS SAM Developer Guide](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html).
+
+Next, you can use the AWS Serverless Application Repository to deploy ready-to-use apps that go beyond Hello World samples and learn how authors developed their applications. For more information, see the [AWS Serverless Application Repository main page](https://aws.amazon.com/serverless/serverlessrepo/) and the [AWS Serverless Application Repository Developer Guide](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/what-is-serverlessrepo.html).

--- a/nodejs10.x/serverless-api-backend/__tests__/unit/handlers/get-all-items.test.js
+++ b/nodejs10.x/serverless-api-backend/__tests__/unit/handlers/get-all-items.test.js
@@ -1,0 +1,47 @@
+// Import dynamodb from aws-sdk
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+// Import all functions from get-all-items.js
+const lambda = require('../../../src/handlers/get-all-items.js');
+
+// This includes all tests for getAllItemsHandler
+describe('Test getAllItemsHandler', () => {
+    let scanSpy;
+
+    // One-time setup and teardown, see more in https://jestjs.io/docs/en/setup-teardown
+    beforeAll(() => {
+        // Mock DynamoDB scan method
+        // https://jestjs.io/docs/en/jest-object.html#jestspyonobject-methodname
+        scanSpy = jest.spyOn(dynamodb.DocumentClient.prototype, 'scan');
+    });
+
+    // Clean up mocks
+    afterAll(() => {
+        scanSpy.mockRestore();
+    });
+
+    // This test invokes getAllItemsHandler and compares the result
+    it('should return ids', async () => {
+        const items = [{ id: 'id1' }, { id: 'id2' }];
+
+        // Return the specified value whenever the spied scan function is called
+        scanSpy.mockReturnValue({
+            promise: () => Promise.resolve({ Items: items }),
+        });
+
+        const event = {
+            httpMethod: 'GET',
+        };
+
+        // Invoke getAllItemsHandler
+        const result = await lambda.getAllItemsHandler(event);
+
+        const expectedResult = {
+            statusCode: 200,
+            body: JSON.stringify(items),
+        };
+
+        // Compare the result with the expected result
+        expect(result).toEqual(expectedResult);
+    });
+});

--- a/nodejs10.x/serverless-api-backend/__tests__/unit/handlers/get-by-id.test.js
+++ b/nodejs10.x/serverless-api-backend/__tests__/unit/handlers/get-by-id.test.js
@@ -1,0 +1,50 @@
+// Import dynamodb from aws-sdk
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+// Import all functions from get-by-id.js
+const lambda = require('../../../src/handlers/get-by-id.js');
+
+// This includes all tests for getByIdHandler
+describe('Test getByIdHandler', () => {
+    let getSpy;
+
+    // One-time setup and teardown, see more in https://jestjs.io/docs/en/setup-teardown
+    beforeAll(() => {
+        // Mock DynamoDB get method
+        // https://jestjs.io/docs/en/jest-object.html#jestspyonobject-methodname
+        getSpy = jest.spyOn(dynamodb.DocumentClient.prototype, 'get');
+    });
+
+    // Clean up mocks
+    afterAll(() => {
+        getSpy.mockRestore();
+    });
+
+    // This test invokes getByIdHandler and compares the result
+    it('should get item by id', async () => {
+        const item = { id: 'id1' };
+
+        // Return the specified value whenever the spied get function is called
+        getSpy.mockReturnValue({
+            promise: () => Promise.resolve({ Item: item }),
+        });
+
+        const event = {
+            httpMethod: 'GET',
+            pathParameters: {
+                id: 'id1',
+            },
+        };
+
+        // Invoke getByIdHandler
+        const result = await lambda.getByIdHandler(event);
+
+        const expectedResult = {
+            statusCode: 200,
+            body: JSON.stringify(item),
+        };
+
+        // Compare the result with the expected result
+        expect(result).toEqual(expectedResult);
+    });
+});

--- a/nodejs10.x/serverless-api-backend/__tests__/unit/handlers/put-item.test.js
+++ b/nodejs10.x/serverless-api-backend/__tests__/unit/handlers/put-item.test.js
@@ -1,0 +1,45 @@
+// Import dynamodb from aws-sdk
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+// Import all functions from put-item.js
+const lambda = require('../../../src/handlers/put-item.js');
+
+// This includes all tests for putItemHandler
+describe('Test putItemHandler', () => {
+    let putSpy;
+
+    // One-time setup and teardown, see more in https://jestjs.io/docs/en/setup-teardown
+    beforeAll(() => {
+        // Mock DynamoDB put method
+        // https://jestjs.io/docs/en/jest-object.html#jestspyonobject-methodname
+        putSpy = jest.spyOn(dynamodb.DocumentClient.prototype, 'put');
+    });
+
+    // Clean up mocks
+    afterAll(() => {
+        putSpy.mockRestore();
+    });
+
+    // This test invokes putItemHandler and compares the result
+    it('should add id to the table', async () => {
+        // Return the specified value whenever the spied put function is called
+        putSpy.mockReturnValue({
+            promise: () => Promise.resolve('data'),
+        });
+
+        const event = {
+            httpMethod: 'POST',
+            body: '{"id":"id1","name":"name1"}',
+        };
+
+        // Invoke putItemHandler()
+        const result = await lambda.putItemHandler(event);
+        const expectedResult = {
+            statusCode: 200,
+            body: event.body,
+        };
+
+        // Compare the result with the expected result
+        expect(result).toEqual(expectedResult);
+    });
+});

--- a/nodejs10.x/serverless-api-backend/buildspec.yml
+++ b/nodejs10.x/serverless-api-backend/buildspec.yml
@@ -1,0 +1,22 @@
+version: 0.2
+phases:
+  install:
+    commands:
+      # Install all dependencies (including dependencies for running tests)
+      - npm install
+  pre_build:
+    commands:
+      # Discover and run unit tests in the '__tests__' directory
+      - npm run test
+      # Remove all unit tests to reduce the size of the package that will be ultimately uploaded to Lambda
+      - rm -rf ./__tests__
+      # Remove all dependencies not needed for the Lambda deployment package (the packages from devDependencies in package.json)
+      - npm prune --production
+  build:
+    commands:
+      # Use AWS SAM to package the application by using AWS CloudFormation
+      - aws cloudformation package --template template.yml --s3-bucket $S3_BUCKET --output-template template-export.yml
+artifacts:
+  type: zip
+  files:
+    - template-export.yml

--- a/nodejs10.x/serverless-api-backend/env.json
+++ b/nodejs10.x/serverless-api-backend/env.json
@@ -1,0 +1,11 @@
+{
+    "getAllItemsFunction": {
+        "SAMPLE_TABLE": "<TABLE-NAME>"
+    },
+    "getByIdFunction": {
+        "SAMPLE_TABLE": "<TABLE-NAME>"
+    },
+    "putItemFunction": {
+        "SAMPLE_TABLE": "<TABLE-NAME>"
+    }
+  }

--- a/nodejs10.x/serverless-api-backend/events/event-get-all-items.json
+++ b/nodejs10.x/serverless-api-backend/events/event-get-all-items.json
@@ -1,0 +1,3 @@
+{
+    "httpMethod": "GET"
+}

--- a/nodejs10.x/serverless-api-backend/events/event-get-by-id.json
+++ b/nodejs10.x/serverless-api-backend/events/event-get-by-id.json
@@ -1,0 +1,6 @@
+{
+    "httpMethod": "GET",
+    "pathParameters": {
+        "id": "id1"
+    }
+}

--- a/nodejs10.x/serverless-api-backend/events/event-post-item.json
+++ b/nodejs10.x/serverless-api-backend/events/event-post-item.json
@@ -1,0 +1,4 @@
+{
+    "httpMethod": "POST",
+    "body": "{\"id\": \"id1\",\"name\": \"name1\"}"
+}

--- a/nodejs10.x/serverless-api-backend/package.json
+++ b/nodejs10.x/serverless-api-backend/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "lambda-api-backend",
+    "description": "Website & Mobile Starter Project",
+    "version": "0.0.1",
+    "private": true,
+    "dependencies": {
+        "aws-sdk": "^2.437.0"
+    },
+    "devDependencies": {
+        "jest": "^24.7.1"
+    },
+    "scripts": {
+        "test": "jest"
+    }
+}

--- a/nodejs10.x/serverless-api-backend/src/handlers/get-all-items.js
+++ b/nodejs10.x/serverless-api-backend/src/handlers/get-all-items.js
@@ -1,0 +1,36 @@
+// Create clients and set shared const values outside of the handler
+
+// Create a DocumentClient that represents the query to get all items
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+const docClient = new dynamodb.DocumentClient();
+
+// Get the DynamoDB table name from environment variables
+const tableName = process.env.SAMPLE_TABLE;
+
+/**
+ * A simple example includes a HTTP get method to get all items from a DynamoDB table.
+ */
+exports.getAllItemsHandler = async (event) => {
+    const { httpMethod, path } = event;
+    if (httpMethod !== 'GET') {
+        throw new Error(`getAllItems only accept GET method, you tried: ${httpMethod}`);
+    }
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    console.log('received:', JSON.stringify(event));
+
+    // get all items from the table (only first 1MB data, you can use `LastEvaluatedKey` to get the rest of data)
+    // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#scan-property
+    // https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html
+    const params = { TableName: tableName };
+    const { Items } = await docClient.scan(params).promise();
+
+    const response = {
+        statusCode: 200,
+        body: JSON.stringify(Items),
+    };
+
+    console.log(`response from: ${path} statusCode: ${response.statusCode} body: ${response.body}`);
+    return response;
+};

--- a/nodejs10.x/serverless-api-backend/src/handlers/get-by-id.js
+++ b/nodejs10.x/serverless-api-backend/src/handlers/get-by-id.js
@@ -1,0 +1,41 @@
+// Create clients and set shared const values outside of the handler
+
+// Create a DocumentClient that represents the query to get an item
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+const docClient = new dynamodb.DocumentClient();
+
+// Get the DynamoDB table name from environment variables
+const tableName = process.env.SAMPLE_TABLE;
+
+/**
+ * A simple example includes a HTTP get method to get one item by id from a DynamoDB table.
+ */
+exports.getByIdHandler = async (event) => {
+    const { httpMethod, path, pathParameters } = event;
+    if (httpMethod !== 'GET') {
+        throw new Error(`getMethod only accept GET method, you tried: ${httpMethod}`);
+    }
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    console.log('received:', JSON.stringify(event));
+
+    // Get id from pathParameters from APIGateway because of `/{id}` at template.yml
+    const { id } = pathParameters;
+
+    // Get the item from the table
+    // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#get-property
+    const params = {
+        TableName: tableName,
+        Key: { id },
+    };
+    const { Item } = await docClient.get(params).promise();
+
+    const response = {
+        statusCode: 200,
+        body: JSON.stringify(Item),
+    };
+
+    console.log(`response from: ${path} statusCode: ${response.statusCode} body: ${response.body}`);
+    return response;
+};

--- a/nodejs10.x/serverless-api-backend/src/handlers/put-item.js
+++ b/nodejs10.x/serverless-api-backend/src/handlers/put-item.js
@@ -1,0 +1,41 @@
+// Create clients and set shared const values outside of the handler
+
+// Create a DocumentClient that represents the query to add an item
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+const docClient = new dynamodb.DocumentClient();
+
+// Get the DynamoDB table name from environment variables
+const tableName = process.env.SAMPLE_TABLE;
+
+/**
+ * A simple example includes a HTTP post method to add one item to a DynamoDB table.
+ */
+exports.putItemHandler = async (event) => {
+    const { body, httpMethod, path } = event;
+    if (httpMethod !== 'POST') {
+        throw new Error(`postMethod only accepts POST method, you tried: ${httpMethod} method.`);
+    }
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    console.log('received:', JSON.stringify(event));
+
+    // Get id and name from the body of the request
+    const { id, name } = JSON.parse(body);
+
+    // Creates a new item, or replaces an old item with a new item
+    // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#put-property
+    const params = {
+        TableName: tableName,
+        Item: { id, name },
+    };
+    await docClient.put(params).promise();
+
+    const response = {
+        statusCode: 200,
+        body,
+    };
+
+    console.log(`response from: ${path} statusCode: ${response.statusCode} body: ${response.body}`);
+    return response;
+};

--- a/nodejs10.x/serverless-api-backend/template.yml
+++ b/nodejs10.x/serverless-api-backend/template.yml
@@ -1,0 +1,124 @@
+# This is the SAM template that represents the architecture of your serverless application
+# https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-template-basics.html
+
+# The AWSTemplateFormatVersion identifies the capabilities of the template
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/format-version-structure.html
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Website & Mobile Starter Project
+
+# Transform section specifies one or more macros that AWS CloudFormation uses to process your template
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-section-structure.html
+Transform: AWS::Serverless-2016-10-31
+
+# Shared configuration for all resources, more in
+# https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
+Globals:
+  Function:
+    # The PermissionsBoundary allows users to safely develop with their function's permissions constrained
+    # to their current application. All the functions and roles in this application have to include it and
+    # it has to be manually updated when you add resources to your application.
+    # More information in https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html
+    PermissionsBoundary: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/${AppId}-${AWS::Region}-PermissionsBoundary'
+
+Parameters:
+  AppId:
+    Type: String
+
+# Resources declares the AWS resources that you want to include in the stack
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html
+Resources:
+  # Each Lambda function is defined by properties:
+  # https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+
+  # This is a Lambda function config associated with the source code: get-all-items.js
+  getAllItemsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: src/handlers/get-all-items.getAllItemsHandler
+      Runtime: nodejs10.x
+      MemorySize: 128
+      Timeout: 60
+      Description: A simple example includes a HTTP get method to get all items from a DynamoDB table.
+      Policies:
+        # Give Create/Read/Update/Delete Permissions to the SampleTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref SampleTable
+      Environment:
+        Variables:
+          # Make table name accessible as environment variable from function code during execution
+          SAMPLE_TABLE: !Ref SampleTable
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /
+            Method: GET
+  # Each Lambda function is defined by properties:
+  # https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+
+  # This is a Lambda function config associated with the source code: get-by-id.js
+  getByIdFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: src/handlers/get-by-id.getByIdHandler
+      Runtime: nodejs10.x
+      MemorySize: 128
+      Timeout: 60
+      Description: A simple example includes a HTTP get method to get one item by id from a DynamoDB table.
+      Policies:
+        # Give Create/Read/Update/Delete Permissions to the SampleTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref SampleTable
+      Environment:
+        Variables:
+          # Make table name accessible as environment variable from function code during execution
+          SAMPLE_TABLE: !Ref SampleTable
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /{id}
+            Method: GET
+  # Each Lambda function is defined by properties:
+  # https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+
+  # This is a Lambda function config associated with the source code: put-item.js
+  putItemFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: src/handlers/put-item.putItemHandler
+      Runtime: nodejs10.x
+      MemorySize: 128
+      Timeout: 60
+      Description: A simple example includes a HTTP post method to add one item to a DynamoDB table.
+      Policies:
+        # Give Create/Read/Update/Delete Permissions to the SampleTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref SampleTable
+      Environment:
+        Variables:
+          # Make table name accessible as environment variable from function code during execution
+          SAMPLE_TABLE: !Ref SampleTable
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /
+            Method: POST
+  # Simple syntax to create a DynamoDB table with a single attribute primary key, more in
+  # https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlesssimpletable
+
+  # DynamoDB table to store item: {id: <ID>, name: <NAME>}
+  SampleTable:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      PrimaryKey:
+        Name: id
+        Type: String
+      ProvisionedThroughput:
+        ReadCapacityUnits: 2
+        WriteCapacityUnits: 2


### PR DESCRIPTION
Add the **Serverless API backend** application. All artifacts are exported from the code repository created from AWS Lambda console by choosing **Serverless API backend** and giving the app name `lambda-api-backend`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
