### PR TITLE
Add notification-processing sample app

### DIFF
--- a/nodejs10.x/notifications-processing/.gitignore
+++ b/nodejs10.x/notifications-processing/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/nodejs10.x/notifications-processing/README.md
+++ b/nodejs10.x/notifications-processing/README.md
@@ -1,0 +1,161 @@
+# Lambda-SNS starter project
+
+This project contains source code and supporting files for the serverless application that you created in the AWS Lambda console. You can update your application at any time by committing and pushing changes to your AWS CodeCommit or GitHub repository.
+
+This project includes the following files and folders:
+
+- src - Code for the application's Lambda function.
+- events - Invocation events that you can use to invoke the function.
+- \_\_tests__ - Unit tests for the application code.
+- template.yml - A SAM template that defines the application's AWS resources.
+- buildspec.yml -  A build specification file that tells AWS CodeBuild how to create a deployment package for the function.
+
+Your Lambda application includes two AWS CloudFormation stacks. The first stack creates the pipeline that builds and deploys your application.
+
+The pipeline creates a second stack that contains your application's resources, including Lambda functions, and an Amazon SNS topic. These resources are defined in the `template.yml` file in this project. You can update the template to add AWS resources through the same deployment process that updates your application code. You can view those resources in the **Resources** section of the application overview in the Lambda console.
+
+For a full list of possible operations, see the [AWS Lambda Applications documentation](https://docs.aws.amazon.com/lambda/latest/dg/deploying-lambda-apps.html).
+
+## Try the application out
+
+1. Go to the Lambda console.
+2. Select **Applications** and select the one you created.
+3. Select **SimpleTopic** in **Resources** table, which will redirect you to the SNS console.
+4. Click on the **SimpleTopic** in the list, then **Publish message** in the top right.
+5. Enter any text you'd like in message body, then click **Publish message**.
+6. Go back to the Lambda console, find your application again and click it.
+7. Select **snsPayloadLoggerFunction** in the **Resources** table.
+8. On the new page, select the **Monitoring** tab, then click **View Logs in CloudWatch**, which will take you to the CloudWatch Logs console.
+9. Click on the latest log stream entry, and you will find your log statement.
+
+## Add a resource to your application
+
+The application template uses the AWS Serverless Application Model (AWS SAM) to define application resources. AWS SAM is an extension of AWS CloudFormation with a simpler syntax for configuring common serverless application resources, such as functions, triggers, and APIs. For resources that aren't included in the [AWS SAM specification](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md), you can use the standard [AWS CloudFormation resource types](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html).
+
+Update `template.yml` to add a dead-letter queue to your application. In the **Resources** section, add a resource named **MyQueue** with the type **AWS::SQS::Queue**.
+
+```
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+```
+
+The dead-letter queue is a location for Lambda to send events that could not be processed. It's only used if you invoke your function asynchronously, but it's useful here to show how you can modify your application's resources and function configuration.
+
+Commit the change and push.
+
+```bash
+my-application$ git commit -am "Add dead-letter queue."
+my-application$ git push
+```
+
+**To see how the pipeline processes and deploys the change**
+
+1. Open the [**Applications**](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Deployments**.
+
+When the deployment completes, view the application resources on the **Overview** tab to see the new resource.
+
+## Update the permissions boundary
+
+The sample application applies a **permissions boundary** to its function's execution role. The permissions boundary limits the permissions that you can add to the function's role. Without the boundary, users with write access to the project repository could modify the project template to give the function permission to access resources and services outside of the scope of the sample application.
+
+In order for the function to use the queue that you added in the previous step, you must extend the permissions boundary. The Lambda console detects resources that aren't in the permissions boundary and provides an updated policy that you can use to update it.
+
+**To update the application's permissions boundary**
+
+1. Open the [**Applications**](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Edit permissions boundary**.
+1. Follow the instructions shown to update the boundary to allow access to the new queue.
+
+## Update the function configuration
+
+Now you can grant the function permission to access the queue and configure the dead-letter queue setting.
+
+In the function's properties in `template.yml`, add the **DeadLetterQueue** configuration. Under Policies, add **SQSSendMessagePolicy**. **SQSSendMessagePolicy** is a [policy template](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-policy-templates.html) that grants the function permission to send messages to a queue.
+
+```
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+  snsPayloadLoggerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: src/handlers/sns-payload-logger.snsPayloadLoggerHandler
+      Runtime: nodejs10.x
+      Description: A Lambda function that logs the payload of messages sent to an associated SNS topic.
+      MemorySize: 128
+      Timeout: 60
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !GetAtt MyQueue.Arn
+      Policies:
+        - SQSSendMessagePolicy:
+            QueueName: !GetAtt MyQueue.QueueName
+        - AWSLambdaBasicExecutionRole
+      Events:
+        SimpleTopicEvent:
+          Type: SNS
+          Properties:
+            Topic: !Ref SimpleTopic
+```
+
+Commit and push the change. When the deployment completes, view the function in the console to see the updated configuration that specifies the dead-letter queue.
+
+## Build and test locally
+
+The AWS SAM command line interface (CLI) is an extension of the AWS CLI that adds functionality for building and testing Lambda applications. It uses Docker to run your functions in an Amazon Linux environment that matches Lambda. It can also emulate your application's build environment and API.
+
+If you prefer to use an integrated development environment (IDE) to build and test your application, you can use the AWS Toolkit.
+The AWS Toolkit is an open-source plugin for popular IDEs that uses the AWS SAM CLI to build and deploy serverless applications on AWS. The AWS Toolkit also adds step-through debugging for Lambda function code.
+
+To get started, see the following:
+
+* [PyCharm](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [IntelliJ](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [VS Code](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html)
+* [Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/welcome.html)
+
+To use the AWS SAM CLI with this sample, you need the following tools:
+
+* AWS CLI - [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) and [configure it with your AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
+* AWS SAM CLI - [Install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html).
+* Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community).
+
+Build your application with the `sam build` command.
+
+```bash
+my-application$ sam build -m package.json
+```
+
+The AWS SAM CLI installs dependencies that are defined in `package.json`, creates a deployment package, and saves its contents in the `.aws-sam/build` folder.
+
+Test a single function by invoking it directly with a test event. An event is a JSON document that represents the input that the function receives from the event source. Test events are included in the `events` folder in this project.
+
+Run functions locally and invoke them with the `sam local invoke` command.
+
+```bash
+my-application$ sam local invoke snsPayloadLoggerFunction --event events/event-sns.json
+```
+
+## Unit tests
+
+Requirements:
+
+* Node.js - [Install Node.js 10](https://nodejs.org/en/), including the npm package management tool.
+
+Tests are defined in the \_\_tests__ folder in this project. Use `npm` to install the [Jest test framework](https://jestjs.io/) and run unit tests.
+
+```bash
+my-application$ npm install
+my-application$ npm run test
+```
+
+## Resources
+
+For an introduction to the AWS SAM specification, the AWS SAM CLI, and serverless application concepts, see the [AWS SAM Developer Guide](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html).
+
+Next, you can use the AWS Serverless Application Repository to deploy ready-to-use apps that go beyond Hello World samples and learn how authors developed their applications. For more information, see the [AWS Serverless Application Repository main page](https://aws.amazon.com/serverless/serverlessrepo/) and the [AWS Serverless Application Repository Developer Guide](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/what-is-serverlessrepo.html).

--- a/nodejs10.x/notifications-processing/__tests__/unit/handlers/sns-payload-logger.test.js
+++ b/nodejs10.x/notifications-processing/__tests__/unit/handlers/sns-payload-logger.test.js
@@ -1,0 +1,29 @@
+// Import all functions from sns-payload-logger.js
+const snsPayloadLogger = require('../../../src/handlers/sns-payload-logger.js');
+
+describe('Test for sns-payload-logger', () => {
+    // This test invokes the sns-payload-logger Lambda function and verifies that the received payload is logged
+    it('Verifies the payload is logged', async () => {
+        // Mock console.log statements so we can verify them. For more information, see
+        // https://jestjs.io/docs/en/mock-functions.html
+        console.log = jest.fn();
+
+        // Create a sample payload with SNS message format
+        const payload = {
+            Records: [{
+                Sns: {
+                    Message: 'This is a notification from SNS',
+                    Subject: 'SNS Notification',
+                    TopicArn: 'arn:aws:sns:us-west-2:123456789012:SimpleTopic',
+                },
+            }],
+        };
+
+        await snsPayloadLogger.snsPayloadLoggerHandler(payload, null);
+
+        // Verify that console.log has been called with the expected payload
+        payload.Records.forEach(({ Sns }, i) => {
+            expect(console.log).toHaveBeenNthCalledWith(i + 1, JSON.stringify(Sns));
+        });
+    });
+});

--- a/nodejs10.x/notifications-processing/buildspec.yml
+++ b/nodejs10.x/notifications-processing/buildspec.yml
@@ -1,0 +1,22 @@
+version: 0.2
+phases:
+  install:
+    commands:
+      # Install all dependencies (including dependencies for running tests)
+      - npm install
+  pre_build:
+    commands:
+      # Discover and run unit tests in the '__tests__' directory
+      - npm run test
+      # Remove all unit tests to reduce the size of the package that will be ultimately uploaded to Lambda
+      - rm -rf ./__tests__
+      # Remove all dependencies not needed for the Lambda deployment package (the packages from devDependencies in package.json)
+      - npm prune --production
+  build:
+    commands:
+      # Use AWS SAM to package the application by using AWS CloudFormation
+      - aws cloudformation package --template template.yml --s3-bucket $S3_BUCKET --output-template template-export.yml
+artifacts:
+  type: zip
+  files:
+    - template-export.yml

--- a/nodejs10.x/notifications-processing/events/event-sns.json
+++ b/nodejs10.x/notifications-processing/events/event-sns.json
@@ -1,0 +1,11 @@
+{
+  "Records": [
+    {
+      "Sns": {
+        "Message": "This is a notification from SNS",
+        "Subject": "SNS Notification",
+        "TopicArn": "arn:aws:sns:us-west-2:123456789012:SimpleTopic"
+      }
+    }
+  ]
+}

--- a/nodejs10.x/notifications-processing/package.json
+++ b/nodejs10.x/notifications-processing/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "lambda-sns",
+    "description": "Lambda-SNS starter project",
+    "version": "0.0.1",
+    "private": true,
+    "dependencies": {
+    },
+    "devDependencies": {
+        "jest": "^24.7.1"
+    },
+    "scripts": {
+        "test": "jest"
+    }
+}

--- a/nodejs10.x/notifications-processing/src/handlers/sns-payload-logger.js
+++ b/nodejs10.x/notifications-processing/src/handlers/sns-payload-logger.js
@@ -1,0 +1,10 @@
+/**
+ * A Lambda function that logs the payload received from SNS.
+ */
+exports.snsPayloadLoggerHandler = async (event, context) => {
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    event.Records.forEach(({ Sns }) => {
+        console.log(JSON.stringify(Sns));
+    });
+};

--- a/nodejs10.x/notifications-processing/template.yml
+++ b/nodejs10.x/notifications-processing/template.yml
@@ -1,0 +1,55 @@
+# This is the SAM template that represents the architecture of your serverless application
+# https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-template-basics.html
+
+# The AWSTemplateFormatVersion identifies the capabilities of the template
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/format-version-structure.html
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Lambda-SNS starter project
+
+# Transform section specifies one or more macros that AWS CloudFormation uses to process your template
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-section-structure.html
+Transform: AWS::Serverless-2016-10-31
+
+# Shared configuration for all resources, more in
+# https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
+Globals:
+  Function:
+    # The PermissionsBoundary allows users to safely develop with their function's permissions constrained
+    # to their current application. All the functions and roles in this application have to include it and
+    # it has to be manually updated when you add resources to your application.
+    # More information in https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html
+    PermissionsBoundary: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/${AppId}-${AWS::Region}-PermissionsBoundary'
+
+Parameters:
+  AppId:
+    Type: String
+
+# Resources declares the AWS resources that you want to include in the stack
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html
+Resources:
+  # Each Lambda function is defined by properties:
+  # https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+
+  # This is a Lambda function config associated with the source code: sns-payload-logger.js
+  snsPayloadLoggerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: src/handlers/sns-payload-logger.snsPayloadLoggerHandler
+      Runtime: nodejs10.x
+      Description: A Lambda function that logs the payload of messages sent to an associated SNS topic.
+      MemorySize: 128
+      Timeout: 60
+      Policies:
+        # Give Lambda basic execution Permission to the snsPayloadLogger
+        - AWSLambdaBasicExecutionRole
+      Events:
+        SimpleTopicEvent:
+          Type: SNS
+          Properties:
+            Topic: !Ref SimpleTopic
+  # This is an SNS Topic with all default configuration properties. To learn more about the available options, see
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sns-topic.html
+  SimpleTopic:
+    Type: AWS::SNS::Topic


### PR DESCRIPTION
Add the **Notification processing** application. All artifacts are exported from the code repository created from AWS Lambda console by choosing **Notification processing** and giving the app name `lambda-sns`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.