### PR TITLE
Add serverless-api-backend CDK app

### DIFF
--- a/nodejs10.x/serverless-api-backend/cdk/.gitignore
+++ b/nodejs10.x/serverless-api-backend/cdk/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/nodejs10.x/serverless-api-backend/cdk/LICENSE
+++ b/nodejs10.x/serverless-api-backend/cdk/LICENSE
@@ -1,0 +1,14 @@
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/nodejs10.x/serverless-api-backend/cdk/README.md
+++ b/nodejs10.x/serverless-api-backend/cdk/README.md
@@ -1,0 +1,207 @@
+# Website & Mobile starter project
+
+This project contains source code and supporting files for the serverless application that you created in the AWS Lambda console. You can update your application at any time by committing and pushing changes to your AWS CodeCommit or GitHub repository.
+
+This project includes the following files and folders:
+
+- src - Code for the application's Lambda function.
+- events - Invocation events that you can use to invoke the function.
+- \_\_tests__ - Unit tests for the application code.
+- cdk - The CDK model that defines the application's AWS resources.
+- buildspec.yml -  A build specification file that tells AWS CodeBuild how to create a deployment package for the function.
+
+Your Lambda application includes two AWS CloudFormation stacks. The first stack creates the pipeline that builds and deploys your application.
+
+The pipeline creates a second stack that contains your application's resources, including Lambda functions, an API Gateway API and an Amazon DynamoDB table. These resources are defined in the `cdk/lib/cdk-stack.ts` file in this project. You can update the CDK model to add AWS resources through the same deployment process that updates your application code. You can view those resources in the **Resources** section of the application overview in the Lambda console.
+
+For a full list of possible operations, see the [AWS Lambda Applications documentation](https://docs.aws.amazon.com/lambda/latest/dg/deploying-lambda-apps.html).
+
+## Try the application out
+
+The sample application creates a RESTful API that takes HTTP requests and invokes Lambda functions. The API has POST and GET methods on the root path to create and list items. It has a GET method that takes an ID path parameter to retrieve items. Each method maps to one of the application's three Lambda functions.
+
+**To use the sample API**
+
+1. Choose your application from the [**Applications page**](https://console.aws.amazon.com/lambda/home#/applications) in the Lambda console. (Make sure you're in the right region)
+1. Copy the URL that's listed under **API endpoint**.
+1. At the command line, use cURL to send POST requests to the application endpoint.
+
+        $ ENDPOINT=<paste-your-endpoint-here>
+        $ curl -d '{"id":"1234ABCD", "name":"My item"}' -H "Content-Type: application/json" -X POST $ENDPOINT
+        {"id":"1234ABCD","name":"My item"}
+        $ curl -d '{"id":"2234ABCD", "name":"My other item"}' -H "Content-Type: application/json" -X POST $ENDPOINT
+        {"id":"2234ABCD","name":"My other item"}
+
+1. Send a GET request to the endpoint to get a list of items.
+
+        $ curl $ENDPOINT
+        [{"id":"1234ABCD","name":"My item"},{"id":"2234ABCD","name":"My other item"}]
+
+1. Send a GET request with the item ID to get a single item.
+
+        $ curl $ENDPOINT/1234ABCD
+        {"id":"1234ABCD","name":"My item"}
+
+To view the application's API, functions, and table, use the links in the **Resources** section of the application overview in the Lambda console.
+
+## Add a resource to your application
+
+The application template uses the AWS Cloud Development Kit (AWS CDK) to define application resources. AWS CDK is an open source software development framework that you can use to model and provision your cloud application resources using familiar programming languages. It provides a library of high-level constructs that simplify resource creation, and an interface for working with CloudFormation resource types directly when needed. When you build an AWS CDK project, the output is a CloudFormation template that defines your application.
+
+The application's resources are defined in `cdk/lib/cdk-stack.ts`. To add a destination to your application, add `@aws-cdk/aws-sqs` and `@aws-cdk/aws-lambda-destinations` to `cdk/package.json`.
+
+```json
+{
+    ...
+    "dependencies": {
+        ...
+        "@aws-cdk/aws-lambda": "^1.31.0",
+        "@aws-cdk/aws-lambda-destinations": "^1.31.0",
+        "@aws-cdk/aws-sqs": "^1.31.0",
+        ...
+    }
+}
+```
+
+Then import the `@aws-cdk/aws-sqs` module and define a `Queue` resource in the class constructor.
+
+**cdk/lib/cdk-stack.ts**
+```typescript
+import * as s3 from '@aws-cdk/aws-s3';
+import { Queue } from '@aws-cdk/aws-sqs';
+...
+
+export class CdkStack extends Stack {
+    constructor(scope: App, id: string, props: StackProps) {
+        super(scope, id, props);
+
+        new CfnParameter(this, 'AppId');
+        // Lambda destination
+        const destination = new Queue(this, 'DestinationQueue');
+        ...
+```
+
+The destination is a location for Lambda to send events that could not be processed. It's only used if you invoke your function asynchronously, but it's useful here to show how you can modify your application's resources and function configuration.
+
+Commit the change and push.
+
+```bash
+my-application$ git commit -am "Add destination queue."
+my-application$ git push
+```
+
+**To see how the pipeline processes and deploys the change**
+
+1. Open the [Applications](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Deployments**.
+
+When the deployment is complete, view the application resources on the **Overview** tab to see the new resource.
+
+## Update the permissions boundary
+
+The sample application applies a **permissions boundary** to its function's execution role. The permissions boundary limits the permissions that you can add to the function's role. Without the boundary, users with write access to the project repository could modify the project template to give the function permission to access resources and services outside of the scope of the sample application.
+
+In order for the function to use the queue that you added in the previous step, you must extend the permissions boundary. The Lambda console detects resources that aren't in the permissions boundary and provides an updated policy that you can use to update it.
+
+**To update the application's permissions boundary**
+
+1. Open the [Applications](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Edit permissions boundary**.
+1. Follow the instructions shown to update the boundary to allow access to the new queue.
+
+## Update the function configuration
+
+Now you can grant the function permission to access the queue and configure the destinations setting.
+
+In the function's properties in `cdk/lib/cdk-stack.ts`, import the `@aws-cdk/aws-lambda-destinations` module and add an `SqsDestination` resource to the **onFailure** destinations configuration.
+
+```typescript
+import { SqsDestination } from '@aws-cdk/aws-lambda-destinations';
+import * as s3 from '@aws-cdk/aws-s3';
+import { Queue } from '@aws-cdk/aws-sqs';
+...
+
+// This is a Lambda function config associated with the source code: get-all-items.js
+const getAllItemsFunction = new lambda.Function(this, 'getAllItems', {
+    description: 'A simple example includes a HTTP get method to get all items from a DynamoDB table.',
+    handler: 'src/handlers/get-all-items.getAllItemsHandler',
+    runtime: lambda.Runtime.NODEJS_10_X,
+    code,
+    environment,
+    timeout: Duration.seconds(60),
+    onFailure: new SqsDestination(destination),
+});
+```
+
+Commit and push the change. When the deployment is complete, view the function in the console to see the updated configuration that specifies the destination.
+
+## Build and test locally
+
+The AWS SAM command line interface (CLI) is an extension of the AWS CLI that adds functionality for building and testing Lambda applications. It uses Docker to run your functions in an Amazon Linux environment that matches Lambda. It can also emulate your application's build environment and API.
+
+If you prefer to use an integrated development environment (IDE) to build and test your application, you can use the AWS Toolkit.
+The AWS Toolkit is an open-source plugin for popular IDEs that uses the AWS SAM CLI to build and deploy serverless applications on AWS. The AWS Toolkit also adds step-through debugging for Lambda function code.
+
+To get started, see the following:
+
+* [PyCharm](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [IntelliJ](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [VS Code](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html)
+* [Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/welcome.html)
+
+To use the AWS SAM CLI with this sample, you need the following tools:
+
+* AWS CLI - [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) and [configure it with your AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
+* AWS SAM CLI - [Install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html).
+* Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community).
+
+Compile your AWS CDK app and create a AWS CloudFormation template
+
+```bash
+my-application$ cd cdk
+cdk$ export S3_BUCKET=mockBucket
+cdk$ cdk synth --no-staging > ../template.yaml
+```
+
+Find the logical ID for your Lambda function in `template.yaml`. It will look like *putItem12345678*, where *12345678* represents an 8-character unique ID that the AWS CDK generates for all resources. The line right after it should look like `Type: AWS::Lambda::Function`.
+
+Test a single function by invoking it directly with a test event. An event is a JSON document that represents the input that the function receives from the event source. Test events are included in the `events` folder in this project.
+
+To invoke the function successfully, modify `env.json` to use correct function names and table name. Replace function names with ones generated in `template.yaml` and `<TABLE-NAME>` with the physical ID of the `SampleTable`. You can find the physical ID from the **Resources** section of the application overview in the Lambda console.
+
+Although functions in `template.yaml` are specified to have deployment package in S3, AWS SAM CLI assumes the source code is in the same local directory as `template.yaml`.
+
+Run functions locally and invoke them with the `sam local invoke` command.
+
+```bash
+my-application$ sam local invoke putItem12345678 --event events/event-post-item.json --env-vars env.json
+my-application$ sam local invoke getAllItems87654321 --event events/event-get-all-items.json --env-vars env.json
+```
+
+The AWS SAM CLI can also emulate your application's API. Use the `sam local start-api` command to run the API locally on port 3000.
+
+```bash
+my-application$ sam local start-api --env-vars env.json
+my-application$ curl http://localhost:3000/
+```
+
+## Unit tests
+
+Requirements:
+
+* Node.js - [Install Node.js 10](https://nodejs.org/en/), including the npm package management tool.
+
+Tests are defined in the \_\_tests__ folder in this project. Use `npm` to install the [Jest test framework](https://jestjs.io/) and run unit tests.
+
+```bash
+my-application$ npm install
+my-application$ npm run test
+```
+
+## Resources
+
+For an introduction to the AWS CDK specification, see the [AWS CDK Developer Guide](https://docs.aws.amazon.com/cdk/latest/guide/home.html).
+
+Next, you can use the AWS Serverless Application Repository to deploy ready-to-use apps that go beyond Hello World samples and learn how authors developed their applications. For more information, see the [AWS Serverless Application Repository main page](https://aws.amazon.com/serverless/serverlessrepo/) and the [AWS Serverless Application Repository Developer Guide](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/what-is-serverlessrepo.html).

--- a/nodejs10.x/serverless-api-backend/cdk/__tests__/unit/handlers/get-all-items.test.js
+++ b/nodejs10.x/serverless-api-backend/cdk/__tests__/unit/handlers/get-all-items.test.js
@@ -1,0 +1,47 @@
+// Import dynamodb from aws-sdk
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+// Import all functions from get-all-items.js
+const lambda = require('../../../src/handlers/get-all-items.js');
+
+// This includes all tests for getAllItemsHandler
+describe('Test getAllItemsHandler', () => {
+    let scanSpy;
+
+    // One-time setup and teardown, see more in https://jestjs.io/docs/en/setup-teardown
+    beforeAll(() => {
+        // Mock DynamoDB scan method
+        // https://jestjs.io/docs/en/jest-object.html#jestspyonobject-methodname
+        scanSpy = jest.spyOn(dynamodb.DocumentClient.prototype, 'scan');
+    });
+
+    // Clean up mocks
+    afterAll(() => {
+        scanSpy.mockRestore();
+    });
+
+    // This test invokes getAllItemsHandler and compares the result
+    it('should return ids', async () => {
+        const items = [{ id: 'id1' }, { id: 'id2' }];
+
+        // Return the specified value whenever the spied scan function is called
+        scanSpy.mockReturnValue({
+            promise: () => Promise.resolve({ Items: items }),
+        });
+
+        const event = {
+            httpMethod: 'GET',
+        };
+
+        // Invoke getAllItemsHandler
+        const result = await lambda.getAllItemsHandler(event);
+
+        const expectedResult = {
+            statusCode: 200,
+            body: JSON.stringify(items),
+        };
+
+        // Compare the result with the expected result
+        expect(result).toEqual(expectedResult);
+    });
+});

--- a/nodejs10.x/serverless-api-backend/cdk/__tests__/unit/handlers/get-by-id.test.js
+++ b/nodejs10.x/serverless-api-backend/cdk/__tests__/unit/handlers/get-by-id.test.js
@@ -1,0 +1,50 @@
+// Import dynamodb from aws-sdk
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+// Import all functions from get-by-id.js
+const lambda = require('../../../src/handlers/get-by-id.js');
+
+// This includes all tests for getByIdHandler
+describe('Test getByIdHandler', () => {
+    let getSpy;
+
+    // One-time setup and teardown, see more in https://jestjs.io/docs/en/setup-teardown
+    beforeAll(() => {
+        // Mock DynamoDB get method
+        // https://jestjs.io/docs/en/jest-object.html#jestspyonobject-methodname
+        getSpy = jest.spyOn(dynamodb.DocumentClient.prototype, 'get');
+    });
+
+    // Clean up mocks
+    afterAll(() => {
+        getSpy.mockRestore();
+    });
+
+    // This test invokes getByIdHandler and compares the result
+    it('should get item by id', async () => {
+        const item = { id: 'id1' };
+
+        // Return the specified value whenever the spied get function is called
+        getSpy.mockReturnValue({
+            promise: () => Promise.resolve({ Item: item }),
+        });
+
+        const event = {
+            httpMethod: 'GET',
+            pathParameters: {
+                id: 'id1',
+            },
+        };
+
+        // Invoke getByIdHandler
+        const result = await lambda.getByIdHandler(event);
+
+        const expectedResult = {
+            statusCode: 200,
+            body: JSON.stringify(item),
+        };
+
+        // Compare the result with the expected result
+        expect(result).toEqual(expectedResult);
+    });
+});

--- a/nodejs10.x/serverless-api-backend/cdk/__tests__/unit/handlers/put-item.test.js
+++ b/nodejs10.x/serverless-api-backend/cdk/__tests__/unit/handlers/put-item.test.js
@@ -1,0 +1,45 @@
+// Import dynamodb from aws-sdk
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+// Import all functions from put-item.js
+const lambda = require('../../../src/handlers/put-item.js');
+
+// This includes all tests for putItemHandler
+describe('Test putItemHandler', () => {
+    let putSpy;
+
+    // One-time setup and teardown, see more in https://jestjs.io/docs/en/setup-teardown
+    beforeAll(() => {
+        // Mock DynamoDB put method
+        // https://jestjs.io/docs/en/jest-object.html#jestspyonobject-methodname
+        putSpy = jest.spyOn(dynamodb.DocumentClient.prototype, 'put');
+    });
+
+    // Clean up mocks
+    afterAll(() => {
+        putSpy.mockRestore();
+    });
+
+    // This test invokes putItemHandler and compares the result
+    it('should add id to the table', async () => {
+        // Return the specified value whenever the spied put function is called
+        putSpy.mockReturnValue({
+            promise: () => Promise.resolve('data'),
+        });
+
+        const event = {
+            httpMethod: 'POST',
+            body: '{"id":"id1","name":"name1"}',
+        };
+
+        // Invoke putItemHandler()
+        const result = await lambda.putItemHandler(event);
+        const expectedResult = {
+            statusCode: 200,
+            body: event.body,
+        };
+
+        // Compare the result with the expected result
+        expect(result).toEqual(expectedResult);
+    });
+});

--- a/nodejs10.x/serverless-api-backend/cdk/buildspec.yml
+++ b/nodejs10.x/serverless-api-backend/cdk/buildspec.yml
@@ -1,0 +1,32 @@
+version: 0.2
+phases:
+  install:
+    commands:
+      # Install all dependencies (including dependencies for running tests)
+      - npm install
+      # Install CDK dependencies
+      - cd cdk
+      - npm install -g aws-cdk
+      - npm install
+      - cd ..
+  pre_build:
+    commands:
+      # Discover and run unit tests in the '__tests__' directory
+      - npm run test
+      # Remove all dependencies not needed for the Lambda deployment package (the packages from devDependencies in package.json)
+      - npm prune --production
+      # Copy artifacts to a separate folder
+      - mkdir function-code
+      - cp -r src node_modules function-code
+  build:
+    commands:
+      # Archive Lambda function code and upload it to S3
+      - cd function-code
+      - zip -r function-code.zip .
+      - aws s3 cp function-code.zip s3://$S3_BUCKET/$CODEBUILD_BUILD_ID/
+      # Use AWS CDK to synthesize the application
+      - cd ../cdk
+      - cdk synth > ../template-export.yml
+artifacts:
+  files:
+    - template-export.yml

--- a/nodejs10.x/serverless-api-backend/cdk/cdk/README.md
+++ b/nodejs10.x/serverless-api-backend/cdk/cdk/README.md
@@ -1,0 +1,8 @@
+# Useful commands
+
+ * `npm run build`   compile typescript to js
+ * `npm run watch`   watch for changes and compile
+ * `npm run test`    perform the jest unit tests
+ * `cdk deploy`      deploy this stack to your default AWS account/region
+ * `cdk diff`        compare deployed stack with current state
+ * `cdk synth`       emits the synthesized CloudFormation template

--- a/nodejs10.x/serverless-api-backend/cdk/cdk/bin/cdk.ts
+++ b/nodejs10.x/serverless-api-backend/cdk/cdk/bin/cdk.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import { App, Aws } from '@aws-cdk/core';
+
+import { CdkStack } from '../lib/cdk-stack';
+import { PermissionsBoundaryAspect } from '../lib/permissions-boundary-aspect';
+
+
+const stack = new CdkStack(new App(), 'CdkStack', { description: 'Website &amp; Mobile Starter Project' });
+const { ACCOUNT_ID, PARTITION, REGION, STACK_NAME } = Aws;
+const permissionBoundaryArn = `arn:${PARTITION}:iam::${ACCOUNT_ID}:policy/${STACK_NAME}-${REGION}-PermissionsBoundary`;
+
+// Apply permissions boundary to the stack
+stack.node.applyAspect(new PermissionsBoundaryAspect(permissionBoundaryArn));

--- a/nodejs10.x/serverless-api-backend/cdk/cdk/cdk.json
+++ b/nodejs10.x/serverless-api-backend/cdk/cdk/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "npx ts-node bin/cdk.ts"
+}

--- a/nodejs10.x/serverless-api-backend/cdk/cdk/jest.config.js
+++ b/nodejs10.x/serverless-api-backend/cdk/cdk/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+    'roots': [
+        '<rootDir>/test'
+    ],
+    testMatch: ['**/*.test.ts'],
+    'transform': {
+        '^.+\\.tsx?$': 'ts-jest'
+    },
+};

--- a/nodejs10.x/serverless-api-backend/cdk/cdk/lib/cdk-stack.ts
+++ b/nodejs10.x/serverless-api-backend/cdk/cdk/lib/cdk-stack.ts
@@ -1,0 +1,68 @@
+import * as apigateway from '@aws-cdk/aws-apigateway';
+import * as dynamodb from '@aws-cdk/aws-dynamodb';
+import * as lambda from '@aws-cdk/aws-lambda';
+import * as s3 from '@aws-cdk/aws-s3';
+import { App, CfnParameter, Duration, Stack, StackProps } from '@aws-cdk/core';
+
+
+export class CdkStack extends Stack {
+    constructor(scope: App, id: string, props: StackProps) {
+        super(scope, id, props);
+
+        new CfnParameter(this, 'AppId');
+
+        // DynamoDB table to store item: {id: <ID>, name: <NAME>}
+        const table = new dynamodb.Table(this, 'SampleTable', {
+            partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
+            readCapacity: 2,
+            writeCapacity: 2
+        });
+
+        const environment = { SAMPLE_TABLE: table.tableName };
+        // The code will be uploaded to this location during the pipeline's build step
+        const artifactBucket = s3.Bucket.fromBucketName(this, 'ArtifactBucket', process.env.S3_BUCKET!);
+        const artifactKey = `${process.env.CODEBUILD_BUILD_ID}/function-code.zip`;
+        const code = lambda.Code.fromBucket(artifactBucket, artifactKey);
+
+        // This is a Lambda function config associated with the source code: get-all-items.js
+        const getAllItemsFunction = new lambda.Function(this, 'getAllItems', {
+            description: 'A simple example includes a HTTP get method to get all items from a DynamoDB table.',
+            handler: 'src/handlers/get-all-items.getAllItemsHandler',
+            runtime: lambda.Runtime.NODEJS_10_X,
+            code,
+            environment,
+            timeout: Duration.seconds(60),
+        });
+        // Give Read permissions to the SampleTable
+        table.grantReadData(getAllItemsFunction);
+
+        // This is a Lambda function config associated with the source code: get-by-id.js
+        const getByIdFunction = new lambda.Function(this, 'getById', {
+            description: 'A simple example includes a HTTP get method to get one item by id from a DynamoDB table.',
+            handler: 'src/handlers/get-by-id.getByIdHandler',
+            runtime: lambda.Runtime.NODEJS_10_X,
+            code,
+            timeout: Duration.seconds(60),
+            environment,
+        });
+        // Give Read permissions to the SampleTable
+        table.grantReadData(getByIdFunction);
+
+        // This is a Lambda function config associated with the source code: put-item.js
+        const putItemFunction = new lambda.Function(this, 'putItem', {
+            description: 'A simple example includes a HTTP post method to add one item to a DynamoDB table.',
+            handler: 'src/handlers/put-item.putItemHandler',
+            runtime: lambda.Runtime.NODEJS_10_X,
+            code,
+            timeout: Duration.seconds(60),
+            environment,
+        });
+        // Give Create/Read/Update/Delete permissions to the SampleTable
+        table.grantReadWriteData(putItemFunction);
+
+        const api = new apigateway.RestApi(this, 'ServerlessRestApi', { cloudWatchRole: false });
+        api.root.addMethod('GET', new apigateway.LambdaIntegration(getAllItemsFunction));
+        api.root.addMethod('POST', new apigateway.LambdaIntegration(putItemFunction));
+        api.root.addResource('{id}').addMethod('GET', new apigateway.LambdaIntegration(getByIdFunction));
+    }
+}

--- a/nodejs10.x/serverless-api-backend/cdk/cdk/lib/permissions-boundary-aspect.ts
+++ b/nodejs10.x/serverless-api-backend/cdk/cdk/lib/permissions-boundary-aspect.ts
@@ -1,0 +1,18 @@
+import * as iam from '@aws-cdk/aws-iam';
+import { IAspect, IConstruct } from '@aws-cdk/core';
+
+
+export class PermissionsBoundaryAspect implements IAspect {
+    private readonly arn: string;
+
+    constructor(permissionBoundaryArn: string) {
+        this.arn = permissionBoundaryArn;
+    }
+
+    public visit(node: IConstruct): void {
+        if (node instanceof iam.Role) {
+            const roleResource = node.node.findChild('Resource') as iam.CfnRole;
+            roleResource.addPropertyOverride('PermissionsBoundary', this.arn);
+        }
+    }
+}

--- a/nodejs10.x/serverless-api-backend/cdk/cdk/package.json
+++ b/nodejs10.x/serverless-api-backend/cdk/cdk/package.json
@@ -1,0 +1,30 @@
+{
+    "name": "lambda-api-backend-cdk",
+    "version": "0.0.1",
+    "bin": {
+        "cdk": "bin/cdk.js"
+    },
+    "scripts": {
+        "build": "tsc",
+        "watch": "tsc -w",
+        "test": "jest",
+        "cdk": "cdk"
+    },
+    "devDependencies": {
+        "@aws-cdk/assert": "^1.31.0",
+        "@types/jest": "^25.2.1",
+        "@types/node": "^10.17.5",
+        "aws-cdk": "^1.31.0",
+        "jest": "^25.4.0",
+        "ts-jest": "^25.4.0",
+        "ts-node": "^8.9.0",
+        "typescript": "^3.8.3"
+    },
+    "dependencies": {
+        "@aws-cdk/aws-apigateway": "^1.31.0",
+        "@aws-cdk/aws-dynamodb": "^1.31.0",
+        "@aws-cdk/aws-lambda": "^1.31.0",
+        "@aws-cdk/aws-s3": "^1.31.0",
+        "@aws-cdk/core": "^1.31.0"
+    }
+}

--- a/nodejs10.x/serverless-api-backend/cdk/cdk/tsconfig.json
+++ b/nodejs10.x/serverless-api-backend/cdk/cdk/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "target": "ES2018",
+        "module": "commonjs",
+        "lib": [
+            "es2016",
+            "es2017.object",
+            "es2017.string"
+        ],
+        "declaration": true,
+        "strict": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "noImplicitThis": true,
+        "alwaysStrict": true,
+        "noUnusedLocals": false,
+        "noUnusedParameters": false,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": false,
+        "inlineSourceMap": true,
+        "inlineSources": true,
+        "experimentalDecorators": true,
+        "strictPropertyInitialization": false,
+        "typeRoots": [
+            "./node_modules/@types"
+        ]
+    },
+    "exclude": [
+        "cdk.out"
+    ]
+}

--- a/nodejs10.x/serverless-api-backend/cdk/env.json
+++ b/nodejs10.x/serverless-api-backend/cdk/env.json
@@ -1,0 +1,11 @@
+{
+    "getAllItems": {
+        "SAMPLE_TABLE": "<TABLE-NAME>"
+    },
+    "getById": {
+        "SAMPLE_TABLE": "<TABLE-NAME>"
+    },
+    "putItem": {
+        "SAMPLE_TABLE": "<TABLE-NAME>"
+    }
+}

--- a/nodejs10.x/serverless-api-backend/cdk/events/event-get-all-items.json
+++ b/nodejs10.x/serverless-api-backend/cdk/events/event-get-all-items.json
@@ -1,0 +1,3 @@
+{
+    "httpMethod": "GET"
+}

--- a/nodejs10.x/serverless-api-backend/cdk/events/event-get-by-id.json
+++ b/nodejs10.x/serverless-api-backend/cdk/events/event-get-by-id.json
@@ -1,0 +1,6 @@
+{
+    "httpMethod": "GET",
+    "pathParameters": {
+        "id": "id1"
+    }
+}

--- a/nodejs10.x/serverless-api-backend/cdk/events/event-post-item.json
+++ b/nodejs10.x/serverless-api-backend/cdk/events/event-post-item.json
@@ -1,0 +1,4 @@
+{
+    "httpMethod": "POST",
+    "body": "{\"id\": \"id1\",\"name\": \"name1\"}"
+}

--- a/nodejs10.x/serverless-api-backend/cdk/package.json
+++ b/nodejs10.x/serverless-api-backend/cdk/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "lambda-api-backend",
+    "description": "Website & Mobile Starter Project",
+    "version": "0.0.1",
+    "private": true,
+    "dependencies": {
+        "aws-sdk": "^2.660.0"
+    },
+    "devDependencies": {
+        "jest": "^25.4.0"
+    },
+    "scripts": {
+        "test": "jest"
+    }
+}

--- a/nodejs10.x/serverless-api-backend/cdk/src/handlers/get-all-items.js
+++ b/nodejs10.x/serverless-api-backend/cdk/src/handlers/get-all-items.js
@@ -1,0 +1,36 @@
+// Create clients and set shared const values outside of the handler
+
+// Create a DocumentClient that represents the query to get all items
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+const docClient = new dynamodb.DocumentClient();
+
+// Get the DynamoDB table name from environment variables
+const tableName = process.env.SAMPLE_TABLE;
+
+/**
+ * A simple example includes a HTTP get method to get all items from a DynamoDB table.
+ */
+exports.getAllItemsHandler = async (event) => {
+    const { httpMethod, path } = event;
+    if (httpMethod !== 'GET') {
+        throw new Error(`getAllItems only accept GET method, you tried: ${httpMethod}`);
+    }
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    console.log('received:', JSON.stringify(event));
+
+    // get all items from the table (only first 1MB data, you can use `LastEvaluatedKey` to get the rest of data)
+    // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#scan-property
+    // https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html
+    const params = { TableName: tableName };
+    const { Items } = await docClient.scan(params).promise();
+
+    const response = {
+        statusCode: 200,
+        body: JSON.stringify(Items),
+    };
+
+    console.log(`response from: ${path} statusCode: ${response.statusCode} body: ${response.body}`);
+    return response;
+};

--- a/nodejs10.x/serverless-api-backend/cdk/src/handlers/get-by-id.js
+++ b/nodejs10.x/serverless-api-backend/cdk/src/handlers/get-by-id.js
@@ -1,0 +1,41 @@
+// Create clients and set shared const values outside of the handler
+
+// Create a DocumentClient that represents the query to get an item
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+const docClient = new dynamodb.DocumentClient();
+
+// Get the DynamoDB table name from environment variables
+const tableName = process.env.SAMPLE_TABLE;
+
+/**
+ * A simple example includes a HTTP get method to get one item by id from a DynamoDB table.
+ */
+exports.getByIdHandler = async (event) => {
+    const { httpMethod, path, pathParameters } = event;
+    if (httpMethod !== 'GET') {
+        throw new Error(`getMethod only accept GET method, you tried: ${httpMethod}`);
+    }
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    console.log('received:', JSON.stringify(event));
+
+    // Get id from pathParameters from APIGateway because of `/{id}` at template.yml
+    const { id } = pathParameters;
+
+    // Get the item from the table
+    // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#get-property
+    const params = {
+        TableName: tableName,
+        Key: { id },
+    };
+    const { Item } = await docClient.get(params).promise();
+
+    const response = {
+        statusCode: 200,
+        body: JSON.stringify(Item),
+    };
+
+    console.log(`response from: ${path} statusCode: ${response.statusCode} body: ${response.body}`);
+    return response;
+};

--- a/nodejs10.x/serverless-api-backend/cdk/src/handlers/put-item.js
+++ b/nodejs10.x/serverless-api-backend/cdk/src/handlers/put-item.js
@@ -1,0 +1,41 @@
+// Create clients and set shared const values outside of the handler
+
+// Create a DocumentClient that represents the query to add an item
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+const docClient = new dynamodb.DocumentClient();
+
+// Get the DynamoDB table name from environment variables
+const tableName = process.env.SAMPLE_TABLE;
+
+/**
+ * A simple example includes a HTTP post method to add one item to a DynamoDB table.
+ */
+exports.putItemHandler = async (event) => {
+    const { body, httpMethod, path } = event;
+    if (httpMethod !== 'POST') {
+        throw new Error(`postMethod only accepts POST method, you tried: ${httpMethod} method.`);
+    }
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    console.log('received:', JSON.stringify(event));
+
+    // Get id and name from the body of the request
+    const { id, name } = JSON.parse(body);
+
+    // Creates a new item, or replaces an old item with a new item
+    // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#put-property
+    const params = {
+        TableName: tableName,
+        Item: { id, name },
+    };
+    await docClient.put(params).promise();
+
+    const response = {
+        statusCode: 200,
+        body,
+    };
+
+    console.log(`response from: ${path} statusCode: ${response.statusCode} body: ${response.body}`);
+    return response;
+};


### PR DESCRIPTION
Add the **Serverless API backend** CDK application. All artifacts are exported from the code repository created from AWS Lambda console by choosing **Serverless API backend** and giving the app name `lambda-api-backend`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
