### PR TITLE
Add author-from-scratch CDK app

### DIFF
--- a/nodejs10.x/author-from-scratch/cdk/.gitignore
+++ b/nodejs10.x/author-from-scratch/cdk/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/nodejs10.x/author-from-scratch/cdk/LICENSE
+++ b/nodejs10.x/author-from-scratch/cdk/LICENSE
@@ -1,0 +1,14 @@
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/nodejs10.x/author-from-scratch/cdk/README.md
+++ b/nodejs10.x/author-from-scratch/cdk/README.md
@@ -1,0 +1,177 @@
+# Start from scratch starter project
+
+This project contains source code and supporting files for the serverless application that you created in the AWS Lambda console. You can update your application at any time by committing and pushing changes to your AWS CodeCommit or GitHub repository.
+
+This project includes the following files and folders:
+
+- src - Code for the application's Lambda function.
+- \_\_tests__ - Unit tests for the application code.
+- cdk - The CDK model that defines the application's AWS resources.
+- buildspec.yml -  A build specification file that tells AWS CodeBuild how to create a deployment package for the function.
+
+Your Lambda application includes two AWS CloudFormation stacks. The first stack creates the pipeline that builds and deploys your application.
+
+The pipeline creates a second stack that contains your application's resources, including Lambda functions. These resources are defined in the `cdk/lib/cdk-stack.ts` file in this project. You can update the CDK model to add AWS resources through the same deployment process that updates your application code. You can view those resources in the **Resources** section of the application overview in the Lambda console.
+
+For a full list of possible operations, see the [AWS Lambda Applications documentation](https://docs.aws.amazon.com/lambda/latest/dg/deploying-lambda-apps.html).
+
+## Try the application out
+
+1. Go to the Lambda console.
+2. Select **Applications** and select the one you created.
+3. Select **helloFromLambda** in the **Resources** table.
+4. Create a test event with the default settings. (Select **Select a test event** -> select **Configure test events** -> type in **Event name** -> select **Create**)
+5. Select **Test** and you can see the result.
+
+## Add a resource to your application
+
+The application template uses the AWS Cloud Development Kit (AWS CDK) to define application resources. AWS CDK is an open source software development framework that you can use to model and provision your cloud application resources using familiar programming languages. It provides a library of high-level constructs that simplify resource creation, and an interface for working with CloudFormation resource types directly when needed. When you build an AWS CDK project, the output is a CloudFormation template that defines your application.
+
+The application's resources are defined in `cdk/lib/cdk-stack.ts`. To add a destination to your application, add `@aws-cdk/aws-sqs` and `@aws-cdk/aws-lambda-destinations` to `cdk/package.json`.
+
+```json
+{
+    ...
+    "dependencies": {
+        ...
+        "@aws-cdk/aws-lambda": "^1.31.0",
+        "@aws-cdk/aws-lambda-destinations": "^1.31.0",
+        "@aws-cdk/aws-sqs": "^1.31.0",
+        ...
+    }
+}
+```
+
+Then import the `@aws-cdk/aws-sqs` module and define a `Queue` resource in the class constructor.
+
+**cdk/lib/cdk-stack.ts**
+```typescript
+import * as s3 from '@aws-cdk/aws-s3';
+import { Queue } from '@aws-cdk/aws-sqs';
+...
+
+export class CdkStack extends Stack {
+    constructor(scope: App, id: string, props: StackProps) {
+        super(scope, id, props);
+
+        new CfnParameter(this, 'AppId');
+        // Lambda destination
+        const destination = new Queue(this, 'DestinationQueue');
+        ...
+```
+
+The destination is a location for Lambda to send events that could not be processed. It's only used if you invoke your function asynchronously, but it's useful here to show how you can modify your application's resources and function configuration.
+
+Commit the change and push.
+
+```bash
+my-application$ git commit -am "Add destination queue."
+my-application$ git push
+```
+
+**To see how the pipeline processes and deploys the change**
+
+1. Open the [Applications](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Deployments**.
+
+When the deployment is complete, view the application resources on the **Overview** tab to see the new resource.
+
+## Update the permissions boundary
+
+The sample application applies a **permissions boundary** to its function's execution role. The permissions boundary limits the permissions that you can add to the function's role. Without the boundary, users with write access to the project repository could modify the project template to give the function permission to access resources and services outside of the scope of the sample application.
+
+In order for the function to use the queue that you added in the previous step, you must extend the permissions boundary. The Lambda console detects resources that aren't in the permissions boundary and provides an updated policy that you can use to update it.
+
+**To update the application's permissions boundary**
+
+1. Open the [Applications](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Edit permissions boundary**.
+1. Follow the instructions shown to update the boundary to allow access to the new queue.
+
+## Update the function configuration
+
+Now you can grant the function permission to access the queue and configure the destinations setting.
+
+In the function's properties in `cdk/lib/cdk-stack.ts`, import the `@aws-cdk/aws-lambda-destinations` module and add an `SqsDestination` resource to the **onFailure** destinations configuration.
+
+```typescript
+import { SqsDestination } from '@aws-cdk/aws-lambda-destinations';
+import * as s3 from '@aws-cdk/aws-s3';
+import { Queue } from '@aws-cdk/aws-sqs';
+...
+
+// This is a Lambda function config associated with the source code: hello-from-lambda.js
+const helloFromLambdaFunction = new lambda.Function(this, 'helloFromLambda', {
+    description: 'A Lambda function that returns a string.',
+    handler: 'src/handlers/hello-from-lambda.helloFromLambdaHandler',
+    runtime: lambda.Runtime.NODEJS_10_X,
+    code: lambda.Code.fromBucket(
+        s3.Bucket.fromBucketName(this, 'ArtifactBucket', artifactBucket),
+        artifactKey,
+    ),
+    onFailure: new SqsDestination(destination),
+});
+```
+
+Commit and push the change. When the deployment is complete, view the function in the console to see the updated configuration that specifies the destination.
+
+## Build and test locally
+
+The AWS SAM command line interface (CLI) is an extension of the AWS CLI that adds functionality for building and testing Lambda applications. It uses Docker to run your functions in an Amazon Linux environment that matches Lambda. It can also emulate your application's build environment and API.
+
+If you prefer to use an integrated development environment (IDE) to build and test your application, you can use the AWS Toolkit.
+The AWS Toolkit is an open-source plugin for popular IDEs that uses the AWS SAM CLI to build and deploy serverless applications on AWS. The AWS Toolkit also adds step-through debugging for Lambda function code.
+
+To get started, see the following:
+
+* [PyCharm](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [IntelliJ](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [VS Code](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html)
+* [Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/welcome.html)
+
+To use the AWS SAM CLI with this sample, you need the following tools:
+
+* AWS CLI - [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) and [configure it with your AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
+* AWS SAM CLI - [Install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html).
+* Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community).
+
+Compile your AWS CDK app and create a AWS CloudFormation template
+
+```bash
+my-application$ cd cdk
+cdk$ export S3_BUCKET=mockBucket
+cdk$ cdk synth --no-staging > ../template.yaml
+```
+
+Find the logical ID for your Lambda function in `template.yaml`. It will look like *helloFromLambda12345678*, where *12345678* represents an 8-character unique ID that the AWS CDK generates for all resources. The line right after it should look like `Type: AWS::Lambda::Function`.
+
+Test a single function by invoking it directly with a test event. An event is a JSON document that represents the input that the function receives from the event source. Test events are included in the `events` folder in this project.
+
+Although functions in `template.yaml` are specified to have deployment package in S3, AWS SAM CLI assumes the source code is in the same local directory as `template.yaml`.
+
+Run functions locally and invoke them with the `sam local invoke` command.
+
+```bash
+my-application$ sam local invoke helloFromLambda12345678 --no-event
+```
+
+## Unit tests
+
+Requirements:
+
+* Node.js - [Install Node.js 10](https://nodejs.org/en/), including the npm package management tool.
+
+Tests are defined in the \_\_tests__ folder in this project. Use `npm` to install the [Jest test framework](https://jestjs.io/) and run unit tests.
+
+```bash
+my-application$ npm install
+my-application$ npm run test
+```
+
+## Resources
+
+For an introduction to the AWS CDK specification, see the [AWS CDK Developer Guide](https://docs.aws.amazon.com/cdk/latest/guide/home.html).
+
+Next, you can use the AWS Serverless Application Repository to deploy ready-to-use apps that go beyond Hello World samples and learn how authors developed their applications. For more information, see the [AWS Serverless Application Repository main page](https://aws.amazon.com/serverless/serverlessrepo/) and the [AWS Serverless Application Repository Developer Guide](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/what-is-serverlessrepo.html).

--- a/nodejs10.x/author-from-scratch/cdk/__tests__/unit/handlers/hello-from-lambda.test.js
+++ b/nodejs10.x/author-from-scratch/cdk/__tests__/unit/handlers/hello-from-lambda.test.js
@@ -1,0 +1,21 @@
+// Import all functions from hello-from-lambda.js
+const lambda = require('../../../src/handlers/hello-from-lambda.js');
+
+describe('Test for hello-from-lambda', () => {
+    // This test invokes the hello-from-lambda Lambda function and compares the result
+    it('Verifies successful response', async () => {
+        // Invoke helloFromLambdaHandler
+        const result = await lambda.helloFromLambdaHandler();
+
+        /*
+            The expected result should match the return from your Lambda function.
+            e.g.
+                If you change from `const message = 'Hello from Lambda!';` to `const message = 'Hello World!';` in hello-from-lambda.js,
+                you should change the following line to `const expectedResult = 'Hello World!';`
+        */
+        const expectedResult = 'Hello from Lambda!';
+
+        // Compare the result with the expected result
+        expect(result).toEqual(expectedResult);
+    });
+});

--- a/nodejs10.x/author-from-scratch/cdk/buildspec.yml
+++ b/nodejs10.x/author-from-scratch/cdk/buildspec.yml
@@ -1,0 +1,32 @@
+version: 0.2
+phases:
+  install:
+    commands:
+      # Install all dependencies (including dependencies for running tests)
+      - npm install
+      # Install CDK dependencies
+      - cd cdk
+      - npm install -g aws-cdk
+      - npm install
+      - cd ..
+  pre_build:
+    commands:
+      # Discover and run unit tests in the '__tests__' directory
+      - npm run test
+      # Remove all dependencies not needed for the Lambda deployment package (the packages from devDependencies in package.json)
+      - npm prune --production
+      # Copy artifacts to a separate folder
+      - mkdir function-code
+      - cp -r src node_modules function-code
+  build:
+    commands:
+      # Archive Lambda function code and upload it to S3
+      - cd function-code
+      - zip -r function-code.zip .
+      - aws s3 cp function-code.zip s3://$S3_BUCKET/$CODEBUILD_BUILD_ID/
+      # Use AWS CDK to synthesize the application
+      - cd ../cdk
+      - cdk synth > ../template-export.yml
+artifacts:
+  files:
+    - template-export.yml

--- a/nodejs10.x/author-from-scratch/cdk/cdk/README.md
+++ b/nodejs10.x/author-from-scratch/cdk/cdk/README.md
@@ -1,0 +1,8 @@
+# Useful commands
+
+ * `npm run build`   compile typescript to js
+ * `npm run watch`   watch for changes and compile
+ * `npm run test`    perform the jest unit tests
+ * `cdk deploy`      deploy this stack to your default AWS account/region
+ * `cdk diff`        compare deployed stack with current state
+ * `cdk synth`       emits the synthesized CloudFormation template

--- a/nodejs10.x/author-from-scratch/cdk/cdk/bin/cdk.ts
+++ b/nodejs10.x/author-from-scratch/cdk/cdk/bin/cdk.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import { App, Aws } from '@aws-cdk/core';
+
+import { CdkStack } from '../lib/cdk-stack';
+import { PermissionsBoundaryAspect } from '../lib/permissions-boundary-aspect';
+
+
+const stack = new CdkStack(new App(), 'CdkStack', { description: 'Start from scratch starter project' });
+const { ACCOUNT_ID, PARTITION, REGION, STACK_NAME } = Aws;
+const permissionBoundaryArn = `arn:${PARTITION}:iam::${ACCOUNT_ID}:policy/${STACK_NAME}-${REGION}-PermissionsBoundary`;
+
+// Apply permissions boundary to the stack
+stack.node.applyAspect(new PermissionsBoundaryAspect(permissionBoundaryArn));

--- a/nodejs10.x/author-from-scratch/cdk/cdk/cdk.json
+++ b/nodejs10.x/author-from-scratch/cdk/cdk/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "npx ts-node bin/cdk.ts"
+}

--- a/nodejs10.x/author-from-scratch/cdk/cdk/jest.config.js
+++ b/nodejs10.x/author-from-scratch/cdk/cdk/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+    'roots': [
+        '<rootDir>/test'
+    ],
+    testMatch: ['**/*.test.ts'],
+    'transform': {
+        '^.+\\.tsx?$': 'ts-jest'
+    },
+};

--- a/nodejs10.x/author-from-scratch/cdk/cdk/lib/cdk-stack.ts
+++ b/nodejs10.x/author-from-scratch/cdk/cdk/lib/cdk-stack.ts
@@ -1,0 +1,27 @@
+import * as lambda from '@aws-cdk/aws-lambda';
+import * as s3 from '@aws-cdk/aws-s3';
+import { App, CfnParameter, Stack, StackProps } from '@aws-cdk/core';
+
+
+export class CdkStack extends Stack {
+    constructor(scope: App, id: string, props: StackProps) {
+        super(scope, id, props);
+
+        new CfnParameter(this, 'AppId');
+
+        // The code will be uploaded to this location during the pipeline's build step
+        const artifactBucket = process.env.S3_BUCKET!;
+        const artifactKey = `${process.env.CODEBUILD_BUILD_ID}/function-code.zip`;
+
+        // This is a Lambda function config associated with the source code: hello-from-lambda.js
+        new lambda.Function(this, 'helloFromLambda', {
+            description: 'A Lambda function that returns a string.',
+            handler: 'src/handlers/hello-from-lambda.helloFromLambdaHandler',
+            runtime: lambda.Runtime.NODEJS_10_X,
+            code: lambda.Code.fromBucket(
+                s3.Bucket.fromBucketName(this, 'ArtifactBucket', artifactBucket),
+                artifactKey,
+            ),
+        });
+    }
+}

--- a/nodejs10.x/author-from-scratch/cdk/cdk/lib/permissions-boundary-aspect.ts
+++ b/nodejs10.x/author-from-scratch/cdk/cdk/lib/permissions-boundary-aspect.ts
@@ -1,0 +1,18 @@
+import * as iam from '@aws-cdk/aws-iam';
+import { IAspect, IConstruct } from '@aws-cdk/core';
+
+
+export class PermissionsBoundaryAspect implements IAspect {
+    private readonly arn: string;
+
+    constructor(permissionBoundaryArn: string) {
+        this.arn = permissionBoundaryArn;
+    }
+
+    public visit(node: IConstruct): void {
+        if (node instanceof iam.Role) {
+            const roleResource = node.node.findChild('Resource') as iam.CfnRole;
+            roleResource.addPropertyOverride('PermissionsBoundary', this.arn);
+        }
+    }
+}

--- a/nodejs10.x/author-from-scratch/cdk/cdk/package.json
+++ b/nodejs10.x/author-from-scratch/cdk/cdk/package.json
@@ -1,0 +1,28 @@
+{
+    "name": "lambda-from-scratch-cdk",
+    "version": "0.0.1",
+    "bin": {
+        "cdk": "bin/cdk.js"
+    },
+    "scripts": {
+        "build": "tsc",
+        "watch": "tsc -w",
+        "test": "jest",
+        "cdk": "cdk"
+    },
+    "devDependencies": {
+        "@aws-cdk/assert": "^1.31.0",
+        "@types/jest": "^25.2.1",
+        "@types/node": "^10.17.5",
+        "aws-cdk": "^1.31.0",
+        "jest": "^25.4.0",
+        "ts-jest": "^25.4.0",
+        "ts-node": "^8.9.0",
+        "typescript": "^3.8.3"
+    },
+    "dependencies": {
+        "@aws-cdk/aws-lambda": "^1.31.0",
+        "@aws-cdk/aws-s3": "^1.31.0",
+        "@aws-cdk/core": "^1.31.0"
+    }
+}

--- a/nodejs10.x/author-from-scratch/cdk/cdk/tsconfig.json
+++ b/nodejs10.x/author-from-scratch/cdk/cdk/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "target": "ES2018",
+        "module": "commonjs",
+        "lib": [
+            "es2016",
+            "es2017.object",
+            "es2017.string"
+        ],
+        "declaration": true,
+        "strict": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "noImplicitThis": true,
+        "alwaysStrict": true,
+        "noUnusedLocals": false,
+        "noUnusedParameters": false,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": false,
+        "inlineSourceMap": true,
+        "inlineSources": true,
+        "experimentalDecorators": true,
+        "strictPropertyInitialization": false,
+        "typeRoots": [
+            "./node_modules/@types"
+        ]
+    },
+    "exclude": [
+        "cdk.out"
+    ]
+}

--- a/nodejs10.x/author-from-scratch/cdk/package.json
+++ b/nodejs10.x/author-from-scratch/cdk/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "lambda-from-scratch",
+    "description": "Start from scratch starter project",
+    "version": "0.0.1",
+    "private": true,
+    "dependencies": {
+    },
+    "devDependencies": {
+        "jest": "^25.4.0"
+    },
+    "scripts": {
+        "test": "jest"
+    }
+}

--- a/nodejs10.x/author-from-scratch/cdk/src/handlers/hello-from-lambda.js
+++ b/nodejs10.x/author-from-scratch/cdk/src/handlers/hello-from-lambda.js
@@ -1,0 +1,13 @@
+/**
+ * A Lambda function that returns a string.
+ */
+exports.helloFromLambdaHandler = async () => {
+    // If you change this message, you will need to adjust tests in hello-from-lambda.test.js
+    const message = 'Hello from Lambda!';
+
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    console.log(message);
+
+    return message;
+};


### PR DESCRIPTION
Add the **Author from scratch** CDK application. All artifacts are exported from the code repository created from AWS Lambda console by choosing **Author from scratch** and giving the app name `lambda-from-scratch`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
