### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/nodejs10.x/author-from-scratch/sam/README.md
+++ b/nodejs10.x/author-from-scratch/sam/README.md
@@ -78,7 +78,7 @@ Resources:
     Properties:
       CodeUri: ./
       Handler: src/handlers/hello-from-lambda.helloFromLambdaHandler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       MemorySize: 128
       Timeout: 60
       DeadLetterQueue:

--- a/nodejs10.x/author-from-scratch/sam/template.yml
+++ b/nodejs10.x/author-from-scratch/sam/template.yml
@@ -37,7 +37,7 @@ Resources:
     Properties:
       CodeUri: ./
       Handler: src/handlers/hello-from-lambda.helloFromLambdaHandler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       MemorySize: 128
       Timeout: 60
       Description: A Lambda function that returns a static string.

--- a/nodejs10.x/file-processing/sam/README.md
+++ b/nodejs10.x/file-processing/sam/README.md
@@ -85,7 +85,7 @@ Resources:
     Properties:
       CodeUri: ./
       Handler: src/handlers/s3-json-logger.s3JsonLoggerHandler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Description: A Lambda function that logs a json file sent to S3 bucket.
       MemorySize: 128
       Timeout: 60

--- a/nodejs10.x/file-processing/sam/template.yml
+++ b/nodejs10.x/file-processing/sam/template.yml
@@ -37,7 +37,7 @@ Resources:
     Properties:
       CodeUri: ./
       Handler: src/handlers/s3-json-logger.s3JsonLoggerHandler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Description: A Lambda function that logs a json file sent to S3 bucket.
       MemorySize: 128
       Timeout: 60

--- a/nodejs10.x/notifications-processing/sam/README.md
+++ b/nodejs10.x/notifications-processing/sam/README.md
@@ -85,7 +85,7 @@ Resources:
     Properties:
       CodeUri: ./
       Handler: src/handlers/sns-payload-logger.snsPayloadLoggerHandler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Description: A Lambda function that logs the payload of messages sent to an associated SNS topic.
       MemorySize: 128
       Timeout: 60

--- a/nodejs10.x/notifications-processing/sam/template.yml
+++ b/nodejs10.x/notifications-processing/sam/template.yml
@@ -37,7 +37,7 @@ Resources:
     Properties:
       CodeUri: ./
       Handler: src/handlers/sns-payload-logger.snsPayloadLoggerHandler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Description: A Lambda function that logs the payload of messages sent to an associated SNS topic.
       MemorySize: 128
       Timeout: 60

--- a/nodejs10.x/queue-processing/sam/README.md
+++ b/nodejs10.x/queue-processing/sam/README.md
@@ -84,7 +84,7 @@ Resources:
     Properties:
       CodeUri: ./
       Handler: src/handlers/sqs-payload-logger.sqsPayloadLoggerHandler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Description: A Lambda function that logs the payload of messages sent to an associated SQS queue.
       MemorySize: 128
       Timeout: 25

--- a/nodejs10.x/queue-processing/sam/template.yml
+++ b/nodejs10.x/queue-processing/sam/template.yml
@@ -37,7 +37,7 @@ Resources:
     Properties:
       CodeUri: ./
       Handler: src/handlers/sqs-payload-logger.sqsPayloadLoggerHandler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Description: A Lambda function that logs the payload of messages sent to an associated SQS queue.
       MemorySize: 128
       Timeout: 25 # Chosen to be less than the default SQS Visibility Timeout of 30 seconds

--- a/nodejs10.x/scheduled-job/sam/README.md
+++ b/nodejs10.x/scheduled-job/sam/README.md
@@ -82,7 +82,7 @@ Resources:
     Properties:
       CodeUri: ./
       Handler: src/handlers/scheduled-event-logger.scheduledEventLoggerHandler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Description: A Lambda function that logs the payload of scheduled events.
       MemorySize: 128
       Timeout: 60

--- a/nodejs10.x/scheduled-job/sam/template.yml
+++ b/nodejs10.x/scheduled-job/sam/template.yml
@@ -37,7 +37,7 @@ Resources:
     Properties:
       CodeUri: ./
       Handler: src/handlers/scheduled-event-logger.scheduledEventLoggerHandler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Description: A Lambda function that logs the payload of scheduled events.
       MemorySize: 128
       Timeout: 60

--- a/nodejs10.x/serverless-api-backend/sam/README.md
+++ b/nodejs10.x/serverless-api-backend/sam/README.md
@@ -101,7 +101,7 @@ Resources:
     Properties:
       CodeUri: ./
       Handler: src/handlers/get-all-items.getAllItemsHandler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       MemorySize: 128
       Timeout: 60
       DeadLetterQueue:

--- a/nodejs10.x/serverless-api-backend/sam/template.yml
+++ b/nodejs10.x/serverless-api-backend/sam/template.yml
@@ -37,7 +37,7 @@ Resources:
     Properties:
       CodeUri: ./
       Handler: src/handlers/get-all-items.getAllItemsHandler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       MemorySize: 128
       Timeout: 60
       Description: A simple example includes a HTTP get method to get all items from a DynamoDB table.
@@ -64,7 +64,7 @@ Resources:
     Properties:
       CodeUri: ./
       Handler: src/handlers/get-by-id.getByIdHandler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       MemorySize: 128
       Timeout: 60
       Description: A simple example includes a HTTP get method to get one item by id from a DynamoDB table.
@@ -91,7 +91,7 @@ Resources:
     Properties:
       CodeUri: ./
       Handler: src/handlers/put-item.putItemHandler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       MemorySize: 128
       Timeout: 60
       Description: A simple example includes a HTTP post method to add one item to a DynamoDB table.


### PR DESCRIPTION
CloudFormation templates in aws-lambda-sample-applications have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.