### PR TITLE
Add sample apps in the nodejs14.x runtime

### DIFF
--- a/nodejs14.x/author-from-scratch/cdk/.gitignore
+++ b/nodejs14.x/author-from-scratch/cdk/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/nodejs14.x/author-from-scratch/cdk/LICENSE
+++ b/nodejs14.x/author-from-scratch/cdk/LICENSE
@@ -1,0 +1,14 @@
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/nodejs14.x/author-from-scratch/cdk/README.md
+++ b/nodejs14.x/author-from-scratch/cdk/README.md
@@ -1,0 +1,177 @@
+# Start from scratch starter project
+
+This project contains source code and supporting files for the serverless application that you created in the AWS Lambda console. You can update your application at any time by committing and pushing changes to your AWS CodeCommit or GitHub repository.
+
+This project includes the following files and folders:
+
+- src - Code for the application's Lambda function.
+- \_\_tests__ - Unit tests for the application code.
+- cdk - The CDK model that defines the application's AWS resources.
+- buildspec.yml -  A build specification file that tells AWS CodeBuild how to create a deployment package for the function.
+
+Your Lambda application includes two AWS CloudFormation stacks. The first stack creates the pipeline that builds and deploys your application.
+
+The pipeline creates a second stack that contains your application's resources, including Lambda functions. These resources are defined in the `cdk/lib/cdk-stack.ts` file in this project. You can update the CDK model to add AWS resources through the same deployment process that updates your application code. You can view those resources in the **Resources** section of the application overview in the Lambda console.
+
+For a full list of possible operations, see the [AWS Lambda Applications documentation](https://docs.aws.amazon.com/lambda/latest/dg/deploying-lambda-apps.html).
+
+## Try the application out
+
+1. Go to the Lambda console.
+2. Select **Applications** and select the one you created.
+3. Select **helloFromLambda** in the **Resources** table.
+4. Create a test event with the default settings. (Select **Select a test event** -> select **Configure test events** -> type in **Event name** -> select **Create**)
+5. Select **Test** and you can see the result.
+
+## Add a resource to your application
+
+The application template uses the AWS Cloud Development Kit (AWS CDK) to define application resources. AWS CDK is an open source software development framework that you can use to model and provision your cloud application resources using familiar programming languages. It provides a library of high-level constructs that simplify resource creation, and an interface for working with CloudFormation resource types directly when needed. When you build an AWS CDK project, the output is a CloudFormation template that defines your application.
+
+The application's resources are defined in `cdk/lib/cdk-stack.ts`. To add a destination to your application, add `@aws-cdk/aws-sqs` and `@aws-cdk/aws-lambda-destinations` to `cdk/package.json`.
+
+```json
+{
+    ...
+    "dependencies": {
+        ...
+        "@aws-cdk/aws-lambda": "^1.31.0",
+        "@aws-cdk/aws-lambda-destinations": "^1.31.0",
+        "@aws-cdk/aws-sqs": "^1.31.0",
+        ...
+    }
+}
+```
+
+Then import the `@aws-cdk/aws-sqs` module and define a `Queue` resource in the class constructor.
+
+**cdk/lib/cdk-stack.ts**
+```typescript
+import * as s3 from '@aws-cdk/aws-s3';
+import { Queue } from '@aws-cdk/aws-sqs';
+...
+
+export class CdkStack extends Stack {
+    constructor(scope: App, id: string, props: StackProps) {
+        super(scope, id, props);
+
+        new CfnParameter(this, 'AppId');
+        // Lambda destination
+        const destination = new Queue(this, 'DestinationQueue');
+        ...
+```
+
+The destination is a location for Lambda to send events that could not be processed. It's only used if you invoke your function asynchronously, but it's useful here to show how you can modify your application's resources and function configuration.
+
+Commit the change and push.
+
+```bash
+my-application$ git commit -am "Add destination queue."
+my-application$ git push
+```
+
+**To see how the pipeline processes and deploys the change**
+
+1. Open the [Applications](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Deployments**.
+
+When the deployment is complete, view the application resources on the **Overview** tab to see the new resource.
+
+## Update the permissions boundary
+
+The sample application applies a **permissions boundary** to its function's execution role. The permissions boundary limits the permissions that you can add to the function's role. Without the boundary, users with write access to the project repository could modify the project template to give the function permission to access resources and services outside of the scope of the sample application.
+
+In order for the function to use the queue that you added in the previous step, you must extend the permissions boundary. The Lambda console detects resources that aren't in the permissions boundary and provides an updated policy that you can use to update it.
+
+**To update the application's permissions boundary**
+
+1. Open the [Applications](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Edit permissions boundary**.
+1. Follow the instructions shown to update the boundary to allow access to the new queue.
+
+## Update the function configuration
+
+Now you can grant the function permission to access the queue and configure the destinations setting.
+
+In the function's properties in `cdk/lib/cdk-stack.ts`, import the `@aws-cdk/aws-lambda-destinations` module and add an `SqsDestination` resource to the **onFailure** destinations configuration.
+
+```typescript
+import { SqsDestination } from '@aws-cdk/aws-lambda-destinations';
+import * as s3 from '@aws-cdk/aws-s3';
+import { Queue } from '@aws-cdk/aws-sqs';
+...
+
+// This is a Lambda function config associated with the source code: hello-from-lambda.js
+const helloFromLambdaFunction = new lambda.Function(this, 'helloFromLambda', {
+    description: 'A Lambda function that returns a string.',
+    handler: 'src/handlers/hello-from-lambda.helloFromLambdaHandler',
+    runtime: lambda.Runtime.NODEJS_14_X,
+    code: lambda.Code.fromBucket(
+        s3.Bucket.fromBucketName(this, 'ArtifactBucket', artifactBucket),
+        artifactKey,
+    ),
+    onFailure: new SqsDestination(destination),
+});
+```
+
+Commit and push the change. When the deployment is complete, view the function in the console to see the updated configuration that specifies the destination.
+
+## Build and test locally
+
+The AWS SAM command line interface (CLI) is an extension of the AWS CLI that adds functionality for building and testing Lambda applications. It uses Docker to run your functions in an Amazon Linux environment that matches Lambda. It can also emulate your application's build environment and API.
+
+If you prefer to use an integrated development environment (IDE) to build and test your application, you can use the AWS Toolkit.
+The AWS Toolkit is an open-source plugin for popular IDEs that uses the AWS SAM CLI to build and deploy serverless applications on AWS. The AWS Toolkit also adds step-through debugging for Lambda function code.
+
+To get started, see the following:
+
+* [PyCharm](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [IntelliJ](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [VS Code](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html)
+* [Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/welcome.html)
+
+To use the AWS SAM CLI with this sample, you need the following tools:
+
+* AWS CLI - [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) and [configure it with your AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
+* AWS SAM CLI - [Install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html).
+* Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community).
+
+Compile your AWS CDK app and create a AWS CloudFormation template
+
+```bash
+my-application$ cd cdk
+cdk$ export S3_BUCKET=mockBucket
+cdk$ cdk synth --no-staging > ../template.yaml
+```
+
+Find the logical ID for your Lambda function in `template.yaml`. It will look like *helloFromLambda12345678*, where *12345678* represents an 8-character unique ID that the AWS CDK generates for all resources. The line right after it should look like `Type: AWS::Lambda::Function`.
+
+Test a single function by invoking it directly with a test event. An event is a JSON document that represents the input that the function receives from the event source. Test events are included in the `events` folder in this project.
+
+Although functions in `template.yaml` are specified to have deployment package in S3, AWS SAM CLI assumes the source code is in the same local directory as `template.yaml`.
+
+Run functions locally and invoke them with the `sam local invoke` command.
+
+```bash
+my-application$ sam local invoke helloFromLambda12345678 --no-event
+```
+
+## Unit tests
+
+Requirements:
+
+* Node.js - [Install Node.js 14.x](https://nodejs.org/en/), including the npm package management tool.
+
+Tests are defined in the \_\_tests__ folder in this project. Use `npm` to install the [Jest test framework](https://jestjs.io/) and run unit tests.
+
+```bash
+my-application$ npm install
+my-application$ npm run test
+```
+
+## Resources
+
+For an introduction to the AWS CDK specification, see the [AWS CDK Developer Guide](https://docs.aws.amazon.com/cdk/latest/guide/home.html).
+
+Next, you can use the AWS Serverless Application Repository to deploy ready-to-use apps that go beyond Hello World samples and learn how authors developed their applications. For more information, see the [AWS Serverless Application Repository main page](https://aws.amazon.com/serverless/serverlessrepo/) and the [AWS Serverless Application Repository Developer Guide](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/what-is-serverlessrepo.html).

--- a/nodejs14.x/author-from-scratch/cdk/__tests__/unit/handlers/hello-from-lambda.test.js
+++ b/nodejs14.x/author-from-scratch/cdk/__tests__/unit/handlers/hello-from-lambda.test.js
@@ -1,0 +1,21 @@
+// Import all functions from hello-from-lambda.js
+const lambda = require('../../../src/handlers/hello-from-lambda.js');
+
+describe('Test for hello-from-lambda', () => {
+    // This test invokes the hello-from-lambda Lambda function and compares the result
+    it('Verifies successful response', async () => {
+        // Invoke helloFromLambdaHandler
+        const result = await lambda.helloFromLambdaHandler();
+
+        /*
+            The expected result should match the return from your Lambda function.
+            e.g.
+                If you change from `const message = 'Hello from Lambda!';` to `const message = 'Hello World!';` in hello-from-lambda.js,
+                you should change the following line to `const expectedResult = 'Hello World!';`
+        */
+        const expectedResult = 'Hello from Lambda!';
+
+        // Compare the result with the expected result
+        expect(result).toEqual(expectedResult);
+    });
+});

--- a/nodejs14.x/author-from-scratch/cdk/buildspec.yml
+++ b/nodejs14.x/author-from-scratch/cdk/buildspec.yml
@@ -1,0 +1,32 @@
+version: 0.2
+phases:
+  install:
+    commands:
+      # Install all dependencies (including dependencies for running tests)
+      - npm install
+      # Install CDK dependencies
+      - cd cdk
+      - npm install -g aws-cdk
+      - npm install
+      - cd ..
+  pre_build:
+    commands:
+      # Discover and run unit tests in the '__tests__' directory
+      - npm run test
+      # Remove all dependencies not needed for the Lambda deployment package (the packages from devDependencies in package.json)
+      - npm prune --production
+      # Copy artifacts to a separate folder
+      - mkdir function-code
+      - cp -r src node_modules function-code
+  build:
+    commands:
+      # Archive Lambda function code and upload it to S3
+      - cd function-code
+      - zip -r function-code.zip .
+      - aws s3 cp function-code.zip s3://$S3_BUCKET/$CODEBUILD_BUILD_ID/
+      # Use AWS CDK to synthesize the application
+      - cd ../cdk
+      - cdk synth > ../template-export.yml
+artifacts:
+  files:
+    - template-export.yml

--- a/nodejs14.x/author-from-scratch/cdk/cdk/README.md
+++ b/nodejs14.x/author-from-scratch/cdk/cdk/README.md
@@ -1,0 +1,8 @@
+# Useful commands
+
+ * `npm run build`   compile typescript to js
+ * `npm run watch`   watch for changes and compile
+ * `npm run test`    perform the jest unit tests
+ * `cdk deploy`      deploy this stack to your default AWS account/region
+ * `cdk diff`        compare deployed stack with current state
+ * `cdk synth`       emits the synthesized CloudFormation template

--- a/nodejs14.x/author-from-scratch/cdk/cdk/bin/cdk.ts
+++ b/nodejs14.x/author-from-scratch/cdk/cdk/bin/cdk.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import { App, Aws } from '@aws-cdk/core';
+
+import { CdkStack } from '../lib/cdk-stack';
+import { PermissionsBoundaryAspect } from '../lib/permissions-boundary-aspect';
+
+
+const stack = new CdkStack(new App(), 'CdkStack', { description: 'Start from scratch starter project' });
+const { ACCOUNT_ID, PARTITION, REGION, STACK_NAME } = Aws;
+const permissionBoundaryArn = `arn:${PARTITION}:iam::${ACCOUNT_ID}:policy/${STACK_NAME}-${REGION}-PermissionsBoundary`;
+
+// Apply permissions boundary to the stack
+stack.node.applyAspect(new PermissionsBoundaryAspect(permissionBoundaryArn));

--- a/nodejs14.x/author-from-scratch/cdk/cdk/cdk.json
+++ b/nodejs14.x/author-from-scratch/cdk/cdk/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "npx ts-node bin/cdk.ts"
+}

--- a/nodejs14.x/author-from-scratch/cdk/cdk/jest.config.js
+++ b/nodejs14.x/author-from-scratch/cdk/cdk/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+    'roots': [
+        '<rootDir>/test'
+    ],
+    testMatch: ['**/*.test.ts'],
+    'transform': {
+        '^.+\\.tsx?$': 'ts-jest'
+    },
+};

--- a/nodejs14.x/author-from-scratch/cdk/cdk/lib/cdk-stack.ts
+++ b/nodejs14.x/author-from-scratch/cdk/cdk/lib/cdk-stack.ts
@@ -1,0 +1,27 @@
+import * as lambda from '@aws-cdk/aws-lambda';
+import * as s3 from '@aws-cdk/aws-s3';
+import { App, CfnParameter, Stack, StackProps } from '@aws-cdk/core';
+
+
+export class CdkStack extends Stack {
+    constructor(scope: App, id: string, props: StackProps) {
+        super(scope, id, props);
+
+        new CfnParameter(this, 'AppId');
+
+        // The code will be uploaded to this location during the pipeline's build step
+        const artifactBucket = process.env.S3_BUCKET!;
+        const artifactKey = `${process.env.CODEBUILD_BUILD_ID}/function-code.zip`;
+
+        // This is a Lambda function config associated with the source code: hello-from-lambda.js
+        new lambda.Function(this, 'helloFromLambda', {
+            description: 'A Lambda function that returns a string.',
+            handler: 'src/handlers/hello-from-lambda.helloFromLambdaHandler',
+            runtime: lambda.Runtime.NODEJS_14_X,
+            code: lambda.Code.fromBucket(
+                s3.Bucket.fromBucketName(this, 'ArtifactBucket', artifactBucket),
+                artifactKey,
+            ),
+        });
+    }
+}

--- a/nodejs14.x/author-from-scratch/cdk/cdk/lib/permissions-boundary-aspect.ts
+++ b/nodejs14.x/author-from-scratch/cdk/cdk/lib/permissions-boundary-aspect.ts
@@ -1,0 +1,18 @@
+import * as iam from '@aws-cdk/aws-iam';
+import { IAspect, IConstruct } from '@aws-cdk/core';
+
+
+export class PermissionsBoundaryAspect implements IAspect {
+    private readonly arn: string;
+
+    constructor(permissionBoundaryArn: string) {
+        this.arn = permissionBoundaryArn;
+    }
+
+    public visit(node: IConstruct): void {
+        if (node instanceof iam.Role) {
+            const roleResource = node.node.findChild('Resource') as iam.CfnRole;
+            roleResource.addPropertyOverride('PermissionsBoundary', this.arn);
+        }
+    }
+}

--- a/nodejs14.x/author-from-scratch/cdk/cdk/package.json
+++ b/nodejs14.x/author-from-scratch/cdk/cdk/package.json
@@ -1,0 +1,28 @@
+{
+    "name": "lambda-from-scratch-cdk",
+    "version": "0.0.1",
+    "bin": {
+        "cdk": "bin/cdk.js"
+    },
+    "scripts": {
+        "build": "tsc",
+        "watch": "tsc -w",
+        "test": "jest",
+        "cdk": "cdk"
+    },
+    "devDependencies": {
+        "@aws-cdk/assert": "^1.31.0",
+        "@types/jest": "^25.2.1",
+        "@types/node": "^10.17.5",
+        "aws-cdk": "^1.31.0",
+        "jest": "^25.4.0",
+        "ts-jest": "^25.4.0",
+        "ts-node": "^8.9.0",
+        "typescript": "^3.8.3"
+    },
+    "dependencies": {
+        "@aws-cdk/aws-lambda": "^1.31.0",
+        "@aws-cdk/aws-s3": "^1.31.0",
+        "@aws-cdk/core": "^1.31.0"
+    }
+}

--- a/nodejs14.x/author-from-scratch/cdk/cdk/package.json
+++ b/nodejs14.x/author-from-scratch/cdk/cdk/package.json
@@ -13,7 +13,7 @@
     "devDependencies": {
         "@aws-cdk/assert": "^1.31.0",
         "@types/jest": "^25.2.1",
-        "@types/node": "^10.17.5",
+        "@types/node": "^14.17.5",
         "aws-cdk": "^1.31.0",
         "jest": "^25.4.0",
         "ts-jest": "^25.4.0",

--- a/nodejs14.x/author-from-scratch/cdk/cdk/tsconfig.json
+++ b/nodejs14.x/author-from-scratch/cdk/cdk/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "target": "ES2018",
+        "module": "commonjs",
+        "lib": [
+            "es2016",
+            "es2017.object",
+            "es2017.string"
+        ],
+        "declaration": true,
+        "strict": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "noImplicitThis": true,
+        "alwaysStrict": true,
+        "noUnusedLocals": false,
+        "noUnusedParameters": false,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": false,
+        "inlineSourceMap": true,
+        "inlineSources": true,
+        "experimentalDecorators": true,
+        "strictPropertyInitialization": false,
+        "typeRoots": [
+            "./node_modules/@types"
+        ]
+    },
+    "exclude": [
+        "cdk.out"
+    ]
+}

--- a/nodejs14.x/author-from-scratch/cdk/package.json
+++ b/nodejs14.x/author-from-scratch/cdk/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "lambda-from-scratch",
+    "description": "Start from scratch starter project",
+    "version": "0.0.1",
+    "private": true,
+    "dependencies": {
+    },
+    "devDependencies": {
+        "jest": "^25.4.0"
+    },
+    "scripts": {
+        "test": "jest"
+    }
+}

--- a/nodejs14.x/author-from-scratch/cdk/src/handlers/hello-from-lambda.js
+++ b/nodejs14.x/author-from-scratch/cdk/src/handlers/hello-from-lambda.js
@@ -1,0 +1,13 @@
+/**
+ * A Lambda function that returns a string.
+ */
+exports.helloFromLambdaHandler = async () => {
+    // If you change this message, you will need to adjust tests in hello-from-lambda.test.js
+    const message = 'Hello from Lambda!';
+
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    console.log(message);
+
+    return message;
+};

--- a/nodejs14.x/author-from-scratch/sam/.gitignore
+++ b/nodejs14.x/author-from-scratch/sam/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/nodejs14.x/author-from-scratch/sam/README.md
+++ b/nodejs14.x/author-from-scratch/sam/README.md
@@ -1,0 +1,146 @@
+# Start from scratch starter project
+
+This project contains source code and supporting files for the serverless application that you created in the AWS Lambda console. You can update your application at any time by committing and pushing changes to your AWS CodeCommit or GitHub repository.
+
+This project includes the following files and folders:
+
+- src - Code for the application's Lambda function.
+- \_\_tests__ - Unit tests for the application code.
+- template.yml - A SAM template that defines the application's AWS resources.
+- buildspec.yml -  A build specification file that tells AWS CodeBuild how to create a deployment package for the function.
+
+Your Lambda application includes two AWS CloudFormation stacks. The first stack creates the pipeline that builds and deploys your application.
+
+For a full list of possible operations, see the [AWS Lambda Applications documentation](https://docs.aws.amazon.com/lambda/latest/dg/deploying-lambda-apps.html).
+
+## Try the application out
+
+1. Go to the Lambda console.
+2. Select **Applications** and select the one you created.
+3. Select **helloFromLambdaFunction** in the **Resources** table.
+4. Create a test event with the default settings. (Select **Select a test event** -> select **Configure test events** -> type in **Event name** -> select **Create**)
+5. Select **Test** and you can see the result.
+
+## Add a resource to your application
+
+The application template uses the AWS Serverless Application Model (AWS SAM) to define application resources. AWS SAM is an extension of AWS CloudFormation with a simpler syntax for configuring common serverless application resources, such as functions, triggers, and APIs. For resources that aren't included in the [AWS SAM specification](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md), you can use the standard [AWS CloudFormation resource types](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html).
+
+Update `template.yml` to add a dead-letter queue to your application. In the **Resources** section, add a resource named **MyQueue** with the type **AWS::SQS::Queue**.
+
+```
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+```
+
+The dead-letter queue is a location for Lambda to send events that could not be processed. It's only used if you invoke your function asynchronously, but it's useful here to show how you can modify your application's resources and function configuration.
+
+Commit the change and push.
+
+```bash
+my-application$ git commit -am "Add dead-letter queue."
+my-application$ git push
+```
+
+**To see how the pipeline processes and deploys the change**
+
+1. Open the [**Applications**](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Deployments**.
+
+When the deployment completes, view the application resources on the **Overview** tab to see the new resource.
+
+## Update the permissions boundary
+
+The sample application applies a **permissions boundary** to its function's execution role. The permissions boundary limits the permissions that you can add to the function's role. Without the boundary, users with write access to the project repository could modify the project template to give the function permission to access resources and services outside of the scope of the sample application.
+
+In order for the function to use the queue that you added in the previous step, you must extend the permissions boundary. The Lambda console detects resources that aren't in the permissions boundary and provides an updated policy that you can use to update it.
+
+**To update the application's permissions boundary**
+
+1. Open the [**Applications**](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Edit permissions boundary**.
+1. Follow the instructions shown to update the boundary to allow access to the new queue.
+
+## Update the function configuration
+
+Now you can grant the function permission to access the queue and configure the dead-letter queue setting.
+
+In the function's properties in `template.yml`, add the **DeadLetterQueue** configuration. Under Policies, add **SQSSendMessagePolicy**. **SQSSendMessagePolicy** is a [policy template](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-policy-templates.html) that grants the function permission to send messages to a queue.
+
+```
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+  helloFromLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: src/handlers/hello-from-lambda.helloFromLambdaHandler
+      Runtime: nodejs14.x
+      MemorySize: 128
+      Timeout: 60
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !GetAtt MyQueue.Arn
+      Policies:
+        - SQSSendMessagePolicy:
+            QueueName: !GetAtt MyQueue.QueueName
+        - AWSLambdaBasicExecutionRole
+```
+
+Commit and push the change. When the deployment completes, view the function in the console to see the updated configuration that specifies the dead-letter queue.
+
+## Build and test locally
+
+The AWS SAM command line interface (CLI) is an extension of the AWS CLI that adds functionality for building and testing Lambda applications. It uses Docker to run your functions in an Amazon Linux environment that matches Lambda. It can also emulate your application's build environment and API.
+
+If you prefer to use an integrated development environment (IDE) to build and test your application, you can use the AWS Toolkit.
+The AWS Toolkit is an open-source plugin for popular IDEs that uses the AWS SAM CLI to build and deploy serverless applications on AWS. The AWS Toolkit also adds step-through debugging for Lambda function code.
+
+To get started, see the following:
+
+* [PyCharm](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [IntelliJ](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [VS Code](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html)
+* [Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/welcome.html)
+
+To use the AWS SAM CLI with this sample, you need the following tools:
+
+* AWS CLI - [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) and [configure it with your AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
+* AWS SAM CLI - [Install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html).
+* Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community).
+
+Build your application with the `sam build` command.
+
+```bash
+my-application$ sam build -m package.json
+```
+
+The AWS SAM CLI installs dependencies that are defined in `package.json`, creates a deployment package, and saves its contents in the `.aws-sam/build` folder.
+
+Run functions locally and invoke them with the `sam local invoke` command.
+
+```bash
+my-application$ sam local invoke helloFromLambdaFunction --no-event
+```
+
+## Unit tests
+
+Requirements:
+
+* Node.js - [Install Node.js 14.x](https://nodejs.org/en/), including the npm package management tool.
+
+Tests are defined in the \_\_tests__ folder in this project. Use `npm` to install the [Jest test framework](https://jestjs.io/) and run unit tests.
+
+```bash
+my-application$ npm install
+my-application$ npm run test
+```
+
+## Resources
+
+For an introduction to the AWS SAM specification, the AWS SAM CLI, and serverless application concepts, see the [AWS SAM Developer Guide](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html).
+
+Next, you can use the AWS Serverless Application Repository to deploy ready-to-use apps that go beyond Hello World samples and learn how authors developed their applications. For more information, see the [AWS Serverless Application Repository main page](https://aws.amazon.com/serverless/serverlessrepo/) and the [AWS Serverless Application Repository Developer Guide](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/what-is-serverlessrepo.html).

--- a/nodejs14.x/author-from-scratch/sam/__tests__/unit/handlers/hello-from-lambda.test.js
+++ b/nodejs14.x/author-from-scratch/sam/__tests__/unit/handlers/hello-from-lambda.test.js
@@ -1,0 +1,21 @@
+// Import all functions from hello-from-lambda.js
+const lambda = require('../../../src/handlers/hello-from-lambda.js');
+
+describe('Test for hello-from-lambda', () => {
+    // This test invokes the hello-from-lambda Lambda function and compares the result
+    it('Verifies successful response', async () => {
+        // Invoke helloFromLambdaHandler
+        const result = await lambda.helloFromLambdaHandler();
+
+        /*
+            The expected result should match the return from your Lambda function.
+            e.g.
+                If you change from `const message = 'Hello from Lambda!';` to `const message = 'Hello World!';` in hello-from-lambda.js,
+                you should change the following line to `const expectedResult = 'Hello World!';`
+        */
+        const expectedResult = 'Hello from Lambda!';
+
+        // Compare the result with the expected result
+        expect(result).toEqual(expectedResult);
+    });
+});

--- a/nodejs14.x/author-from-scratch/sam/buildspec.yml
+++ b/nodejs14.x/author-from-scratch/sam/buildspec.yml
@@ -1,0 +1,22 @@
+version: 0.2
+phases:
+  install:
+    commands:
+      # Install all dependencies (including dependencies for running tests)
+      - npm install
+  pre_build:
+    commands:
+      # Discover and run unit tests in the '__tests__' directory
+      - npm run test
+      # Remove all unit tests to reduce the size of the package that will be ultimately uploaded to Lambda
+      - rm -rf ./__tests__
+      # Remove all dependencies not needed for the Lambda deployment package (the packages from devDependencies in package.json)
+      - npm prune --production
+  build:
+    commands:
+      # Use AWS SAM to package the application by using AWS CloudFormation
+      - aws cloudformation package --template template.yml --s3-bucket $S3_BUCKET --output-template template-export.yml
+artifacts:
+  type: zip
+  files:
+    - template-export.yml

--- a/nodejs14.x/author-from-scratch/sam/package.json
+++ b/nodejs14.x/author-from-scratch/sam/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "lambda-from-scratch",
+    "description": "Start from scratch starter project",
+    "version": "0.0.1",
+    "private": true,
+    "dependencies": {
+    },
+    "devDependencies": {
+        "jest": "^24.7.1"
+    },
+    "scripts": {
+        "test": "jest"
+    }
+}

--- a/nodejs14.x/author-from-scratch/sam/src/handlers/hello-from-lambda.js
+++ b/nodejs14.x/author-from-scratch/sam/src/handlers/hello-from-lambda.js
@@ -1,0 +1,13 @@
+/**
+ * A Lambda function that returns a string.
+ */
+exports.helloFromLambdaHandler = async () => {
+    // If you change this message, you will need to adjust tests in hello-from-lambda.test.js
+    const message = 'Hello from Lambda!';
+
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    console.log(message);
+
+    return message;
+};

--- a/nodejs14.x/author-from-scratch/sam/template.yml
+++ b/nodejs14.x/author-from-scratch/sam/template.yml
@@ -1,0 +1,46 @@
+# This is the SAM template that represents the architecture of your serverless application
+# https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-template-basics.html
+
+# The AWSTemplateFormatVersion identifies the capabilities of the template
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/format-version-structure.html
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Start from scratch starter project
+
+# Transform section specifies one or more macros that AWS CloudFormation uses to process your template
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-section-structure.html
+Transform: AWS::Serverless-2016-10-31
+
+# Shared configuration for all resources, more in
+# https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
+Globals:
+  Function:
+    # The PermissionsBoundary allows users to safely develop with their function's permissions constrained
+    # to their current application. All the functions and roles in this application have to include it and
+    # it has to be manually updated when you add resources to your application.
+    # More information in https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html
+    PermissionsBoundary: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/${AppId}-${AWS::Region}-PermissionsBoundary'
+
+Parameters:
+  AppId:
+    Type: String
+
+# Resources declares the AWS resources that you want to include in the stack
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html
+Resources:
+  # Each Lambda function is defined by properties:
+  # https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+
+  # This is a Lambda function config associated with the source code: hello-from-lambda.js
+  helloFromLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: src/handlers/hello-from-lambda.helloFromLambdaHandler
+      Runtime: nodejs14.x
+      MemorySize: 128
+      Timeout: 60
+      Description: A Lambda function that returns a static string.
+      Policies:
+        # Give Lambda basic execution Permission to the helloFromLambda
+        - AWSLambdaBasicExecutionRole

--- a/nodejs14.x/file-processing/cdk/.gitignore
+++ b/nodejs14.x/file-processing/cdk/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/nodejs14.x/file-processing/cdk/LICENSE
+++ b/nodejs14.x/file-processing/cdk/LICENSE
@@ -1,0 +1,14 @@
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/nodejs14.x/file-processing/cdk/README.md
+++ b/nodejs14.x/file-processing/cdk/README.md
@@ -1,0 +1,187 @@
+# Lambda-S3 starter project
+
+This project contains source code and supporting files for the serverless application that you created in the AWS Lambda console. You can update your application at any time by committing and pushing changes to your AWS CodeCommit or GitHub repository.
+
+This project includes the following files and folders:
+
+- src - Code for the application's Lambda function.
+- events - Invocation events that you can use to invoke the function.
+- \_\_tests__ - Unit tests for the application code.
+- cdk - The CDK model that defines the application's AWS resources.
+- buildspec.yml -  A build specification file that tells AWS CodeBuild how to create a deployment package for the function.
+
+Your Lambda application includes two AWS CloudFormation stacks. The first stack creates the pipeline that builds and deploys your application.
+
+The pipeline creates a second stack that contains your application's resources, including Lambda functions and an Amazon S3 bucket. These resources are defined in the `cdk/lib/cdk-stack.ts` file in this project. You can update the CDK model to add AWS resources through the same deployment process that updates your application code. You can view those resources in the **Resources** section of the application overview in the Lambda console.
+
+For a full list of possible operations, see the [AWS Lambda Applications documentation](https://docs.aws.amazon.com/lambda/latest/dg/deploying-lambda-apps.html).
+
+## Try the application out
+
+1. Go to the Lambda console.
+2. Select **Applications** and select the one you created.
+3. Select **S3Bucket** in **Resources** table, which will redirect you to the S3 console.
+4. Click on the **Upload** tab, then click **Add files** to choose a file that ends in `.json` to add to the bucket. You can use the example file in the repository, found at `__tests__/s3-example/log.json`.
+5. Go back to the Lambda console, and find your application again.
+6. Select **s3JsonLogger** in the **Resources** table.
+7. Select the **Monitoring** tab, then click **View logs in CloudWatch**, which will take you to the CloudWatch Logs console.
+8. Click on the latest log stream entry, and you will find the content of the file you added to the S3 bucket in the log stream.
+
+## Add a resource to your application
+
+The application template uses the AWS Cloud Development Kit (AWS CDK) to define application resources. AWS CDK is an open source software development framework that you can use to model and provision your cloud application resources using familiar programming languages. It provides a library of high-level constructs that simplify resource creation, and an interface for working with CloudFormation resource types directly when needed. When you build an AWS CDK project, the output is a CloudFormation template that defines your application.
+
+The application's resources are defined in `cdk/lib/cdk-stack.ts`. To add a destination to your application, add `@aws-cdk/aws-sqs` and `@aws-cdk/aws-lambda-destinations` to `cdk/package.json`.
+
+```json
+{
+    ...
+    "dependencies": {
+        ...
+        "@aws-cdk/aws-lambda": "^1.31.0",
+        "@aws-cdk/aws-lambda-destinations": "^1.31.0",
+        "@aws-cdk/aws-sqs": "^1.31.0",
+        ...
+    }
+}
+```
+
+Then import the `@aws-cdk/aws-sqs` module and define a `Queue` resource in the class constructor.
+
+**cdk/lib/cdk-stack.ts**
+```typescript
+import * as s3 from '@aws-cdk/aws-s3';
+import { Queue } from '@aws-cdk/aws-sqs';
+...
+
+export class CdkStack extends Stack {
+    constructor(scope: App, id: string, props: StackProps) {
+        super(scope, id, props);
+
+        new CfnParameter(this, 'AppId');
+        // Lambda destination
+        const destination = new Queue(this, 'DestinationQueue');
+        ...
+```
+
+The destination is a location for Lambda to send events that could not be processed. It's only used if you invoke your function asynchronously, but it's useful here to show how you can modify your application's resources and function configuration.
+
+Commit the change and push.
+
+```bash
+my-application$ git commit -am "Add destination queue."
+my-application$ git push
+```
+
+**To see how the pipeline processes and deploys the change**
+
+1. Open the [Applications](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Deployments**.
+
+When the deployment is complete, view the application resources on the **Overview** tab to see the new resource.
+
+## Update the permissions boundary
+
+The sample application applies a **permissions boundary** to its function's execution role. The permissions boundary limits the permissions that you can add to the function's role. Without the boundary, users with write access to the project repository could modify the project template to give the function permission to access resources and services outside of the scope of the sample application.
+
+In order for the function to use the queue that you added in the previous step, you must extend the permissions boundary. The Lambda console detects resources that aren't in the permissions boundary and provides an updated policy that you can use to update it.
+
+**To update the application's permissions boundary**
+
+1. Open the [Applications](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Edit permissions boundary**.
+1. Follow the instructions shown to update the boundary to allow access to the new queue.
+
+## Update the function configuration
+
+Now you can grant the function permission to access the queue and configure the destinations setting.
+
+In the function's properties in `cdk/lib/cdk-stack.ts`, import the `@aws-cdk/aws-lambda-destinations` module and add an `SqsDestination` resource to the **onFailure** destinations configuration.
+
+```typescript
+import { SqsDestination } from '@aws-cdk/aws-lambda-destinations';
+import * as s3 from '@aws-cdk/aws-s3';
+import { Queue } from '@aws-cdk/aws-sqs';
+...
+
+// This is a Lambda function config associated with the source code: s3-json-logger.js
+const s3JsonLoggerFunction = new lambda.Function(this, 's3JsonLogger', {
+    description: 'A Lambda function that logs a json file sent to S3 bucket.',
+    handler: 'src/handlers/s3-json-logger.s3JsonLoggerHandler',
+    runtime: lambda.Runtime.NODEJS_14_X,
+    code: lambda.Code.fromBucket(
+        s3.Bucket.fromBucketName(this, 'ArtifactBucket', artifactBucket),
+        artifactKey,
+    ),
+    events: [
+        new S3EventSource(
+            bucket,
+            { events: [s3.EventType.OBJECT_CREATED], filters: [{ suffix: '.json' }] }
+        ),
+    ],
+    onFailure: new SqsDestination(destination),
+});
+```
+
+Commit and push the change. When the deployment is complete, view the function in the console to see the updated configuration that specifies the destination.
+
+## Build and test locally
+
+The AWS SAM command line interface (CLI) is an extension of the AWS CLI that adds functionality for building and testing Lambda applications. It uses Docker to run your functions in an Amazon Linux environment that matches Lambda. It can also emulate your application's build environment and API.
+
+If you prefer to use an integrated development environment (IDE) to build and test your application, you can use the AWS Toolkit.
+The AWS Toolkit is an open-source plugin for popular IDEs that uses the AWS SAM CLI to build and deploy serverless applications on AWS. The AWS Toolkit also adds step-through debugging for Lambda function code.
+
+To get started, see the following:
+
+* [PyCharm](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [IntelliJ](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [VS Code](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html)
+* [Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/welcome.html)
+
+To use the AWS SAM CLI with this sample, you need the following tools:
+
+* AWS CLI - [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) and [configure it with your AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
+* AWS SAM CLI - [Install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html).
+* Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community).
+
+Compile your AWS CDK app and create a AWS CloudFormation template
+
+```bash
+my-application$ cd cdk
+cdk$ export S3_BUCKET=mockBucket
+cdk$ cdk synth --no-staging > ../template.yaml
+```
+
+Find the logical ID for your Lambda function in `template.yaml`. It will look like *s3JsonLogger12345678*, where *12345678* represents an 8-character unique ID that the AWS CDK generates for all resources. The line right after it should look like `Type: AWS::Lambda::Function`.
+
+Test a single function by invoking it directly with a test event. An event is a JSON document that represents the input that the function receives from the event source. Test events are included in the `events` folder in this project. To invoke the function successfully, upload a JSON file to the `simpleappbucket` created in the stack. Change the `s3.bucket.name` and `s3.object.key` in `event-s3.json` to the actual bucket name and key.
+
+Although functions in `template.yaml` are specified to have deployment package in S3, AWS SAM CLI assumes the source code is in the same local directory as `template.yaml`.
+
+Run functions locally and invoke them with the `sam local invoke` command.
+
+```bash
+my-application$ sam local invoke s3JsonLogger12345678 --event events/event-s3.json
+```
+
+## Unit tests
+
+Requirements:
+
+* Node.js - [Install Node.js 14.x](https://nodejs.org/en/), including the npm package management tool.
+
+Tests are defined in the \_\_tests__ folder in this project. Use `npm` to install the [Jest test framework](https://jestjs.io/) and run unit tests.
+
+```bash
+my-application$ npm install
+my-application$ npm run test
+```
+
+## Resources
+
+For an introduction to the AWS CDK specification, see the [AWS CDK Developer Guide](https://docs.aws.amazon.com/cdk/latest/guide/home.html).
+
+Next, you can use the AWS Serverless Application Repository to deploy ready-to-use apps that go beyond Hello World samples and learn how authors developed their applications. For more information, see the [AWS Serverless Application Repository main page](https://aws.amazon.com/serverless/serverlessrepo/) and the [AWS Serverless Application Repository Developer Guide](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/what-is-serverlessrepo.html).

--- a/nodejs14.x/file-processing/cdk/__tests__/s3-example/log.json
+++ b/nodejs14.x/file-processing/cdk/__tests__/s3-example/log.json
@@ -1,0 +1,11 @@
+[{
+    "namespace": "session",
+    "createTime": "2019-01-01T12:00:00.000Z",
+    "data": [{
+        "name": "end",
+        "value": 50,
+        "unit": "Milliseconds",
+        "metadata": {}
+    }]
+}]
+

--- a/nodejs14.x/file-processing/cdk/__tests__/unit/handlers/s3-json-logger.test.js
+++ b/nodejs14.x/file-processing/cdk/__tests__/unit/handlers/s3-json-logger.test.js
@@ -1,0 +1,42 @@
+// Import mock AWS SDK from aws-sdk-mock
+const AWS = require('aws-sdk-mock');
+
+describe('Test for s3-json-logger', () => {
+    // This test invokes the s3-json-logger Lambda function and verifies that the received payload is logged
+    it('Verifies the object is read and the payload is logged', async () => {
+        const objectBody = '{"Test": "PASS"}';
+        const getObjectResponse = { Body: objectBody };
+        AWS.mock('S3', 'getObject', (params, callback) => {
+            callback(null, getObjectResponse);
+        });
+
+        // Mock console.log statements so we can verify them. For more information, see
+        // https://jestjs.io/docs/en/mock-functions.html
+        console.log = jest.fn();
+
+        // Create a sample payload with S3 message format
+        const event = {
+            Records: [
+                {
+                    s3: {
+                        bucket: {
+                            name: 'test-bucket',
+                        },
+                        object: {
+                            key: 'test-key',
+                        },
+                    },
+                },
+            ],
+        };
+
+        // Import all functions from s3-json-logger.js. The imported module uses the mock AWS SDK
+        const s3JsonLogger = require('../../../src/handlers/s3-json-logger.js');
+        await s3JsonLogger.s3JsonLoggerHandler(event, null);
+
+        // Verify that console.log has been called with the expected payload
+        expect(console.log).toHaveBeenCalledWith(objectBody);
+
+        AWS.restore('S3');
+    });
+});

--- a/nodejs14.x/file-processing/cdk/buildspec.yml
+++ b/nodejs14.x/file-processing/cdk/buildspec.yml
@@ -1,0 +1,32 @@
+version: 0.2
+phases:
+  install:
+    commands:
+      # Install all dependencies (including dependencies for running tests)
+      - npm install
+      # Install CDK dependencies
+      - cd cdk
+      - npm install -g aws-cdk
+      - npm install
+      - cd ..
+  pre_build:
+    commands:
+      # Discover and run unit tests in the '__tests__' directory
+      - npm run test
+      # Remove all dependencies not needed for the Lambda deployment package (the packages from devDependencies in package.json)
+      - npm prune --production
+      # Copy artifacts to a separate folder
+      - mkdir function-code
+      - cp -r src node_modules function-code
+  build:
+    commands:
+      # Archive Lambda function code and upload it to S3
+      - cd function-code
+      - zip -r function-code.zip .
+      - aws s3 cp function-code.zip s3://$S3_BUCKET/$CODEBUILD_BUILD_ID/
+      # Use AWS CDK to synthesize the application
+      - cd ../cdk
+      - cdk synth > ../template-export.yml
+artifacts:
+  files:
+    - template-export.yml

--- a/nodejs14.x/file-processing/cdk/cdk/README.md
+++ b/nodejs14.x/file-processing/cdk/cdk/README.md
@@ -1,0 +1,8 @@
+# Useful commands
+
+ * `npm run build`   compile typescript to js
+ * `npm run watch`   watch for changes and compile
+ * `npm run test`    perform the jest unit tests
+ * `cdk deploy`      deploy this stack to your default AWS account/region
+ * `cdk diff`        compare deployed stack with current state
+ * `cdk synth`       emits the synthesized CloudFormation template

--- a/nodejs14.x/file-processing/cdk/cdk/bin/cdk.ts
+++ b/nodejs14.x/file-processing/cdk/cdk/bin/cdk.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import { App, Aws } from '@aws-cdk/core';
+
+import { CdkStack } from '../lib/cdk-stack';
+import { PermissionsBoundaryAspect } from '../lib/permissions-boundary-aspect';
+
+
+const stack = new CdkStack(new App(), 'CdkStack', { description: 'Lambda-S3 starter project' });
+const { ACCOUNT_ID, PARTITION, REGION, STACK_NAME } = Aws;
+const permissionBoundaryArn = `arn:${PARTITION}:iam::${ACCOUNT_ID}:policy/${STACK_NAME}-${REGION}-PermissionsBoundary`;
+
+// Apply permissions boundary to the stack
+stack.node.applyAspect(new PermissionsBoundaryAspect(permissionBoundaryArn));

--- a/nodejs14.x/file-processing/cdk/cdk/cdk.json
+++ b/nodejs14.x/file-processing/cdk/cdk/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "npx ts-node bin/cdk.ts"
+}

--- a/nodejs14.x/file-processing/cdk/cdk/jest.config.js
+++ b/nodejs14.x/file-processing/cdk/cdk/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+    'roots': [
+        '<rootDir>/test'
+    ],
+    testMatch: ['**/*.test.ts'],
+    'transform': {
+        '^.+\\.tsx?$': 'ts-jest'
+    },
+};

--- a/nodejs14.x/file-processing/cdk/cdk/lib/cdk-stack.ts
+++ b/nodejs14.x/file-processing/cdk/cdk/lib/cdk-stack.ts
@@ -1,0 +1,42 @@
+import * as lambda from '@aws-cdk/aws-lambda';
+import { S3EventSource } from '@aws-cdk/aws-lambda-event-sources';
+import * as s3 from '@aws-cdk/aws-s3';
+import { App, CfnParameter, Stack, StackProps } from '@aws-cdk/core';
+
+
+export class CdkStack extends Stack {
+    constructor(scope: App, id: string, props: StackProps) {
+        super(scope, id, props);
+
+        const appId = new CfnParameter(this, 'AppId');
+
+        // The code will be uploaded to this location during the pipeline's build step
+        const artifactBucket = process.env.S3_BUCKET!;
+        const artifactKey = `${process.env.CODEBUILD_BUILD_ID}/function-code.zip`;
+
+        // Create an S3 bucket, with the given name
+        const bucketId = 'simpleappbucket';
+        const bucket = new s3.Bucket(this, bucketId, {
+            bucketName: ['aws', this.region, this.account, appId.value.toString(), bucketId].join('-'),
+        });
+
+        // This is a Lambda function config associated with the source code: s3-json-logger.js
+        const s3JsonLoggerFunction = new lambda.Function(this, 's3JsonLogger', {
+            description: 'A Lambda function that logs a json file sent to S3 bucket.',
+            handler: 'src/handlers/s3-json-logger.s3JsonLoggerHandler',
+            runtime: lambda.Runtime.NODEJS_14_X,
+            code: lambda.Code.fromBucket(
+                s3.Bucket.fromBucketName(this, 'ArtifactBucket', artifactBucket),
+                artifactKey,
+            ),
+            events: [
+                new S3EventSource(
+                    bucket,
+                    { events: [s3.EventType.OBJECT_CREATED], filters: [{ suffix: '.json' }] }
+                ),
+            ],
+        });
+        // Give Read permissions to the S3 bucket
+        bucket.grantRead(s3JsonLoggerFunction);
+    }
+}

--- a/nodejs14.x/file-processing/cdk/cdk/lib/permissions-boundary-aspect.ts
+++ b/nodejs14.x/file-processing/cdk/cdk/lib/permissions-boundary-aspect.ts
@@ -1,0 +1,18 @@
+import * as iam from '@aws-cdk/aws-iam';
+import { IAspect, IConstruct } from '@aws-cdk/core';
+
+
+export class PermissionsBoundaryAspect implements IAspect {
+    private readonly arn: string;
+
+    constructor(permissionBoundaryArn: string) {
+        this.arn = permissionBoundaryArn;
+    }
+
+    public visit(node: IConstruct): void {
+        if (node instanceof iam.Role) {
+            const roleResource = node.node.findChild('Resource') as iam.CfnRole;
+            roleResource.addPropertyOverride('PermissionsBoundary', this.arn);
+        }
+    }
+}

--- a/nodejs14.x/file-processing/cdk/cdk/package.json
+++ b/nodejs14.x/file-processing/cdk/cdk/package.json
@@ -1,0 +1,29 @@
+{
+    "name": "lambda-s3-cdk",
+    "version": "0.0.1",
+    "bin": {
+        "cdk": "bin/cdk.js"
+    },
+    "scripts": {
+        "build": "tsc",
+        "watch": "tsc -w",
+        "test": "jest",
+        "cdk": "cdk"
+    },
+    "devDependencies": {
+        "@aws-cdk/assert": "^1.31.0",
+        "@types/jest": "^25.2.1",
+        "@types/node": "^10.17.5",
+        "aws-cdk": "^1.31.0",
+        "jest": "^25.4.0",
+        "ts-jest": "^25.4.0",
+        "ts-node": "^8.9.0",
+        "typescript": "^3.8.3"
+    },
+    "dependencies": {
+        "@aws-cdk/aws-lambda-event-sources": "^1.31.0",
+        "@aws-cdk/aws-lambda": "^1.31.0",
+        "@aws-cdk/aws-s3": "^1.31.0",
+        "@aws-cdk/core": "^1.31.0"
+    }
+}

--- a/nodejs14.x/file-processing/cdk/cdk/package.json
+++ b/nodejs14.x/file-processing/cdk/cdk/package.json
@@ -13,7 +13,7 @@
     "devDependencies": {
         "@aws-cdk/assert": "^1.31.0",
         "@types/jest": "^25.2.1",
-        "@types/node": "^10.17.5",
+        "@types/node": "^14.17.5",
         "aws-cdk": "^1.31.0",
         "jest": "^25.4.0",
         "ts-jest": "^25.4.0",

--- a/nodejs14.x/file-processing/cdk/cdk/tsconfig.json
+++ b/nodejs14.x/file-processing/cdk/cdk/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "target": "ES2018",
+        "module": "commonjs",
+        "lib": [
+            "es2016",
+            "es2017.object",
+            "es2017.string"
+        ],
+        "declaration": true,
+        "strict": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "noImplicitThis": true,
+        "alwaysStrict": true,
+        "noUnusedLocals": false,
+        "noUnusedParameters": false,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": false,
+        "inlineSourceMap": true,
+        "inlineSources": true,
+        "experimentalDecorators": true,
+        "strictPropertyInitialization": false,
+        "typeRoots": [
+            "./node_modules/@types"
+        ]
+    },
+    "exclude": [
+        "cdk.out"
+    ]
+}

--- a/nodejs14.x/file-processing/cdk/events/event-s3.json
+++ b/nodejs14.x/file-processing/cdk/events/event-s3.json
@@ -1,0 +1,38 @@
+{
+  "Records": [
+    {
+      "eventVersion": "2.0",
+      "eventSource": "aws:s3",
+      "awsRegion": "us-east-1",
+      "eventTime": "1970-01-01T00:00:00.000Z",
+      "eventName": "ObjectCreated:Put",
+      "userIdentity": {
+        "principalId": "EXAMPLE"
+      },
+      "requestParameters": {
+        "sourceIPAddress": "127.0.0.1"
+      },
+      "responseElements": {
+        "x-amz-request-id": "EXAMPLE123456789",
+        "x-amz-id-2": "EXAMPLE123/5678abcdefghijklambdaisawesome/mnopqrstuvwxyzABCDEFGH"
+      },
+      "s3": {
+        "s3SchemaVersion": "1.0",
+        "configurationId": "testConfigRule",
+        "bucket": {
+          "name": "example-bucket",
+          "ownerIdentity": {
+            "principalId": "EXAMPLE"
+          },
+          "arn": "arn:aws:s3:::example-bucket"
+        },
+        "object": {
+          "key": "test/key",
+          "size": 1024,
+          "eTag": "0123456789abcdef0123456789abcdef",
+          "sequencer": "0A1B2C3D4E5F678901"
+        }
+      }
+    }
+  ]
+}

--- a/nodejs14.x/file-processing/cdk/package.json
+++ b/nodejs14.x/file-processing/cdk/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "lambda-s3",
+    "description": "Lambda-S3 starter project",
+    "version": "0.0.1",
+    "private": true,
+    "dependencies": {
+        "aws-sdk": "^2.660.0"
+    },
+    "devDependencies": {
+        "aws-sdk-mock": "^5.1.0",
+        "jest": "^25.4.0"
+    },
+    "scripts": {
+        "test": "jest"
+    }
+}

--- a/nodejs14.x/file-processing/cdk/src/handlers/s3-json-logger.js
+++ b/nodejs14.x/file-processing/cdk/src/handlers/s3-json-logger.js
@@ -1,0 +1,29 @@
+// Create clients outside of the handler
+
+// Create a client to read objects from S3
+const AWS = require('aws-sdk');
+
+const s3 = new AWS.S3();
+
+/**
+  * A Lambda function that logs the payload received from S3.
+  */
+exports.s3JsonLoggerHandler = async (event, context) => {
+    const getObjectRequests = event.Records.map(async (record) => {
+        const params = {
+            Bucket: record.s3.bucket.name,
+            Key: record.s3.object.key,
+        };
+        try {
+            const { Body } = await s3.getObject(params).promise();
+            // All log statements are written to CloudWatch by default. For more information, see
+            // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+            console.log(Body.toString());
+        } catch (error) {
+            console.error('Error calling S3 getObject:', error);
+            throw error;
+        }
+    });
+
+    await Promise.all(getObjectRequests);
+};

--- a/nodejs14.x/file-processing/sam/.gitignore
+++ b/nodejs14.x/file-processing/sam/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/nodejs14.x/file-processing/sam/README.md
+++ b/nodejs14.x/file-processing/sam/README.md
@@ -1,0 +1,168 @@
+# Lambda-S3 starter project
+
+This project contains source code and supporting files for the serverless application that you created in the AWS Lambda console. You can update your application at any time by committing and pushing changes to your AWS CodeCommit or GitHub repository.
+
+This project includes the following files and folders:
+
+- src - Code for the application's Lambda function.
+- events - Invocation events that you can use to invoke the function.
+- \_\_tests__ - Unit tests for the application code.
+- template.yml - A SAM template that defines the application's AWS resources.
+- buildspec.yml -  A build specification file that tells AWS CodeBuild how to create a deployment package for the function.
+
+Your Lambda application includes two AWS CloudFormation stacks. The first stack creates the pipeline that builds and deploys your application.
+
+The pipeline creates a second stack that contains your application's resources, including Lambda functions, and an Amazon S3 bucket. These resources are defined in the `template.yml` file in this project. You can update the template to add AWS resources through the same deployment process that updates your application code. You can view those resources in the **Resources** section of the application overview in the Lambda console.
+
+For a full list of possible operations, see the [AWS Lambda Applications documentation](https://docs.aws.amazon.com/lambda/latest/dg/deploying-lambda-apps.html).
+
+## Try the application out
+
+1. Go to the Lambda console.
+2. Select **Applications** and select the one you created.
+3. Select **S3Bucket** in **Resources** table, which will redirect you to the S3 console.
+4. Click on the **Upload** tab, then click **Add files** to choose a file that ends in `.json` to add to the bucket. You can use the example file in the repository, found at `__tests__/s3-example/log.json`.
+5. Go back to the Lambda console, and find your application again.
+6. Select **s3JsonLoggerFunction** in the **Resources** table.
+7. Select the **Monitoring** tab, then click **View logs in CloudWatch**, which will take you to the CloudWatch Logs console.
+8. Click on the latest log stream entry, and you will find the content of the file you added to the S3 bucket in the log stream.
+
+
+## Add a resource to your application
+
+The application template uses the AWS Serverless Application Model (AWS SAM) to define application resources. AWS SAM is an extension of AWS CloudFormation with a simpler syntax for configuring common serverless application resources, such as functions, triggers, and APIs. For resources that aren't included in the [AWS SAM specification](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md), you can use the standard [AWS CloudFormation resource types](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html).
+
+Update `template.yml` to add a dead-letter queue to your application. In the **Resources** section, add a resource named **MyQueue** with the type **AWS::SQS::Queue**.
+
+```
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+```
+
+The dead-letter queue is a location for Lambda to send events that could not be processed. It's only used if you invoke your function asynchronously, but it's useful here to show how you can modify your application's resources and function configuration.
+
+Commit the change and push.
+
+```bash
+my-application$ git commit -am "Add dead-letter queue."
+my-application$ git push
+```
+
+**To see how the pipeline processes and deploys the change**
+
+1. Open the [**Applications**](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Deployments**.
+
+When the deployment completes, view the application resources on the **Overview** tab to see the new resource.
+
+## Update the permissions boundary
+
+The sample application applies a **permissions boundary** to its function's execution role. The permissions boundary limits the permissions that you can add to the function's role. Without the boundary, users with write access to the project repository could modify the project template to give the function permission to access resources and services outside of the scope of the sample application.
+
+In order for the function to use the queue that you added in the previous step, you must extend the permissions boundary. The Lambda console detects resources that aren't in the permissions boundary and provides an updated policy that you can use to update it.
+
+**To update the application's permissions boundary**
+
+1. Open the [**Applications**](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Edit permissions boundary**.
+1. Follow the instructions shown to update the boundary to allow access to the new queue.
+
+## Update the function configuration
+
+Now you can grant the function permission to access the queue and configure the dead-letter queue setting.
+
+In the function's properties in `template.yml`, add the **DeadLetterQueue** configuration. Under Policies, add **SQSSendMessagePolicy**. **SQSSendMessagePolicy** is a [policy template](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-policy-templates.html) that grants the function permission to send messages to a queue.
+
+```
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+  s3JsonLoggerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: src/handlers/s3-json-logger.s3JsonLoggerHandler
+      Runtime: nodejs14.x
+      Description: A Lambda function that logs a json file sent to S3 bucket.
+      MemorySize: 128
+      Timeout: 60
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !GetAtt MyQueue.Arn
+      Policies:
+        - SQSSendMessagePolicy:
+            QueueName: !GetAtt MyQueue.QueueName
+        - S3ReadPolicy:
+            BucketName: !Sub aws-${AWS::Region}-${AWS::AccountId}-${AppId}-simpleappbucket
+      Events:
+        simpleappbucketEvent:
+          Type: S3
+          Properties:
+            Bucket: !Ref simpleappbucket
+            Events: s3:ObjectCreated:*
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: suffix
+                    Value: ".json"
+```
+
+Commit and push the change. When the deployment completes, view the function in the console to see the updated configuration that specifies the dead-letter queue.
+
+## Build and test locally
+
+The AWS SAM command line interface (CLI) is an extension of the AWS CLI that adds functionality for building and testing Lambda applications. It uses Docker to run your functions in an Amazon Linux environment that matches Lambda. It can also emulate your application's build environment and API.
+
+If you prefer to use an integrated development environment (IDE) to build and test your application, you can use the AWS Toolkit.
+The AWS Toolkit is an open-source plugin for popular IDEs that uses the AWS SAM CLI to build and deploy serverless applications on AWS. The AWS Toolkit also adds step-through debugging for Lambda function code.
+
+To get started, see the following:
+
+* [PyCharm](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [IntelliJ](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [VS Code](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html)
+* [Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/welcome.html)
+
+To use the AWS SAM CLI with this sample, you need the following tools:
+
+* AWS CLI - [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) and [configure it with your AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
+* AWS SAM CLI - [Install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html).
+* Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community).
+
+Build your application with the `sam build` command.
+
+```bash
+my-application$ sam build -m package.json
+```
+
+The AWS SAM CLI installs dependencies that are defined in `package.json`, creates a deployment package, and saves its contents in the `.aws-sam/build` folder.
+
+Test a single function by invoking it directly with a test event. An event is a JSON document that represents the input that the function receives from the event source. Test events are included in the `events` folder in this project.
+
+Run functions locally and invoke them with the `sam local invoke` command.
+
+```bash
+my-application$ sam local invoke s3JsonLoggerFunction --event events/event-s3.json
+```
+
+## Unit tests
+
+Requirements:
+
+* Node.js - [Install Node.js 14.x](https://nodejs.org/en/), including the npm package management tool.
+
+Tests are defined in the \_\_tests__ folder in this project. Use `npm` to install the [Jest test framework](https://jestjs.io/) and run unit tests.
+
+```bash
+my-application$ npm install
+my-application$ npm run test
+```
+
+## Resources
+
+For an introduction to the AWS SAM specification, the AWS SAM CLI, and serverless application concepts, see the [AWS SAM Developer Guide](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html).
+
+Next, you can use the AWS Serverless Application Repository to deploy ready-to-use apps that go beyond Hello World samples and learn how authors developed their applications. For more information, see the [AWS Serverless Application Repository main page](https://aws.amazon.com/serverless/serverlessrepo/) and the [AWS Serverless Application Repository Developer Guide](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/what-is-serverlessrepo.html).

--- a/nodejs14.x/file-processing/sam/__tests__/s3-example/log.json
+++ b/nodejs14.x/file-processing/sam/__tests__/s3-example/log.json
@@ -1,0 +1,11 @@
+[{
+    "namespace": "session",
+    "createTime": "2019-01-01T12:00:00.000Z",
+    "data": [{
+        "name": "end",
+        "value": 50,
+        "unit": "Milliseconds",
+        "metadata": {}
+    }]
+}]
+

--- a/nodejs14.x/file-processing/sam/__tests__/unit/handlers/s3-json-logger.test.js
+++ b/nodejs14.x/file-processing/sam/__tests__/unit/handlers/s3-json-logger.test.js
@@ -1,0 +1,42 @@
+// Import mock AWS SDK from aws-sdk-mock
+const AWS = require('aws-sdk-mock');
+
+describe('Test for s3-json-logger', () => {
+    // This test invokes the s3-json-logger Lambda function and verifies that the received payload is logged
+    it('Verifies the object is read and the payload is logged', async () => {
+        const objectBody = '{"Test": "PASS"}';
+        const getObjectResponse = { Body: objectBody };
+        AWS.mock('S3', 'getObject', (params, callback) => {
+            callback(null, getObjectResponse);
+        });
+
+        // Mock console.log statements so we can verify them. For more information, see
+        // https://jestjs.io/docs/en/mock-functions.html
+        console.log = jest.fn();
+
+        // Create a sample payload with S3 message format
+        const event = {
+            Records: [
+                {
+                    s3: {
+                        bucket: {
+                            name: 'test-bucket',
+                        },
+                        object: {
+                            key: 'test-key',
+                        },
+                    },
+                },
+            ],
+        };
+
+        // Import all functions from s3-json-logger.js. The imported module uses the mock AWS SDK
+        const s3JsonLogger = require('../../../src/handlers/s3-json-logger.js');
+        await s3JsonLogger.s3JsonLoggerHandler(event, null);
+
+        // Verify that console.log has been called with the expected payload
+        expect(console.log).toHaveBeenCalledWith(objectBody);
+
+        AWS.restore('S3');
+    });
+});

--- a/nodejs14.x/file-processing/sam/buildspec.yml
+++ b/nodejs14.x/file-processing/sam/buildspec.yml
@@ -1,0 +1,22 @@
+version: 0.2
+phases:
+  install:
+    commands:
+      # Install all dependencies (including dependencies for running tests)
+      - npm install
+  pre_build:
+    commands:
+      # Discover and run unit tests in the '__tests__' directory
+      - npm run test
+      # Remove all unit tests to reduce the size of the package that will be ultimately uploaded to Lambda
+      - rm -rf ./__tests__
+      # Remove all dependencies not needed for the Lambda deployment package (the packages from devDependencies in package.json)
+      - npm prune --production
+  build:
+    commands:
+      # Use AWS SAM to package the application by using AWS CloudFormation
+      - aws cloudformation package --template template.yml --s3-bucket $S3_BUCKET --output-template template-export.yml
+artifacts:
+  type: zip
+  files:
+    - template-export.yml

--- a/nodejs14.x/file-processing/sam/events/event-s3.json
+++ b/nodejs14.x/file-processing/sam/events/event-s3.json
@@ -1,0 +1,38 @@
+{
+  "Records": [
+    {
+      "eventVersion": "2.0",
+      "eventSource": "aws:s3",
+      "awsRegion": "us-east-1",
+      "eventTime": "1970-01-01T00:00:00.000Z",
+      "eventName": "ObjectCreated:Put",
+      "userIdentity": {
+        "principalId": "EXAMPLE"
+      },
+      "requestParameters": {
+        "sourceIPAddress": "127.0.0.1"
+      },
+      "responseElements": {
+        "x-amz-request-id": "EXAMPLE123456789",
+        "x-amz-id-2": "EXAMPLE123/5678abcdefghijklambdaisawesome/mnopqrstuvwxyzABCDEFGH"
+      },
+      "s3": {
+        "s3SchemaVersion": "1.0",
+        "configurationId": "testConfigRule",
+        "bucket": {
+          "name": "example-bucket",
+          "ownerIdentity": {
+            "principalId": "EXAMPLE"
+          },
+          "arn": "arn:aws:s3:::example-bucket"
+        },
+        "object": {
+          "key": "test/key",
+          "size": 1024,
+          "eTag": "0123456789abcdef0123456789abcdef",
+          "sequencer": "0A1B2C3D4E5F678901"
+        }
+      }
+    }
+  ]
+}

--- a/nodejs14.x/file-processing/sam/package.json
+++ b/nodejs14.x/file-processing/sam/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "lambda-s3",
+    "description": "Lambda-S3 starter project",
+    "version": "0.0.1",
+    "private": true,
+    "dependencies": {
+        "aws-sdk": "^2.437.0"
+    },
+    "devDependencies": {
+        "aws-sdk-mock": "^4.5.0",
+        "jest": "^24.7.1"
+    },
+    "scripts": {
+        "test": "jest"
+    }
+}

--- a/nodejs14.x/file-processing/sam/src/handlers/s3-json-logger.js
+++ b/nodejs14.x/file-processing/sam/src/handlers/s3-json-logger.js
@@ -1,0 +1,29 @@
+// Create clients outside of the handler
+
+// Create a client to read objects from S3
+const AWS = require('aws-sdk');
+
+const s3 = new AWS.S3();
+
+/**
+  * A Lambda function that logs the payload received from S3.
+  */
+exports.s3JsonLoggerHandler = async (event, context) => {
+    const getObjectRequests = event.Records.map(async (record) => {
+        const params = {
+            Bucket: record.s3.bucket.name,
+            Key: record.s3.object.key,
+        };
+        try {
+            const { Body } = await s3.getObject(params).promise();
+            // All log statements are written to CloudWatch by default. For more information, see
+            // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+            console.log(Body.toString());
+        } catch (error) {
+            console.error('Error calling S3 getObject:', error);
+            throw error;
+        }
+    });
+
+    await Promise.all(getObjectRequests);
+};

--- a/nodejs14.x/file-processing/sam/template.yml
+++ b/nodejs14.x/file-processing/sam/template.yml
@@ -1,0 +1,62 @@
+# This is the SAM template that represents the architecture of your serverless application
+# https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-template-basics.html
+
+# The AWSTemplateFormatVersion identifies the capabilities of the template
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/format-version-structure.html
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Lambda-S3 starter project
+
+# Transform section specifies one or more macros that AWS CloudFormation uses to process your template
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-section-structure.html
+Transform: AWS::Serverless-2016-10-31
+
+# Shared configuration for all resources, more in
+# https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
+Globals:
+  Function:
+    # The PermissionsBoundary allows users to safely develop with their function's permissions constrained
+    # to their current application. All the functions and roles in this application have to include it and
+    # it has to be manually updated when you add resources to your application.
+    # More information in https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html
+    PermissionsBoundary: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/${AppId}-${AWS::Region}-PermissionsBoundary'
+
+Parameters:
+  AppId:
+    Type: String
+
+# Resources declares the AWS resources that you want to include in the stack
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html
+Resources:
+  # Each Lambda function is defined by properties:
+  # https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+
+  # This is a Lambda function config associated with the source code: s3-json-logger.js
+  s3JsonLoggerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: src/handlers/s3-json-logger.s3JsonLoggerHandler
+      Runtime: nodejs14.x
+      Description: A Lambda function that logs a json file sent to S3 bucket.
+      MemorySize: 128
+      Timeout: 60
+      Policies:
+        # Give Read Permissions to the S3 Bucket
+        - S3ReadPolicy:
+            BucketName: !Sub aws-${AWS::Region}-${AWS::AccountId}-${AppId}-simpleappbucket
+      Events:
+        simpleappbucketEvent:
+          Type: S3
+          Properties:
+            Bucket: !Ref simpleappbucket
+            Events: s3:ObjectCreated:*
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: suffix
+                    Value: ".json"
+  simpleappbucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub aws-${AWS::Region}-${AWS::AccountId}-${AppId}-simpleappbucket

--- a/nodejs14.x/notifications-processing/cdk/.gitignore
+++ b/nodejs14.x/notifications-processing/cdk/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/nodejs14.x/notifications-processing/cdk/LICENSE
+++ b/nodejs14.x/notifications-processing/cdk/LICENSE
@@ -1,0 +1,14 @@
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/nodejs14.x/notifications-processing/cdk/README.md
+++ b/nodejs14.x/notifications-processing/cdk/README.md
@@ -1,0 +1,183 @@
+# Lambda-SNS starter project
+
+This project contains source code and supporting files for the serverless application that you created in the AWS Lambda console. You can update your application at any time by committing and pushing changes to your AWS CodeCommit or GitHub repository.
+
+This project includes the following files and folders:
+
+- src - Code for the application's Lambda function.
+- events - Invocation events that you can use to invoke the function.
+- \_\_tests__ - Unit tests for the application code.
+- cdk - The CDK model that defines the application's AWS resources.
+- buildspec.yml -  A build specification file that tells AWS CodeBuild how to create a deployment package for the function.
+
+Your Lambda application includes two AWS CloudFormation stacks. The first stack creates the pipeline that builds and deploys your application.
+
+The pipeline creates a second stack that contains your application's resources, including Lambda functions and an Amazon SNS topic. These resources are defined in the `cdk/lib/cdk-stack.ts` file in this project. You can update the CDK model to add AWS resources through the same deployment process that updates your application code. You can view those resources in the **Resources** section of the application overview in the Lambda console.
+
+For a full list of possible operations, see the [AWS Lambda Applications documentation](https://docs.aws.amazon.com/lambda/latest/dg/deploying-lambda-apps.html).
+
+## Try the application out
+
+1. Go to the Lambda console.
+2. Select **Applications** and select the one you created.
+3. Select **SimpleTopic** in **Resources** table, which will redirect you to the SNS console.
+4. Click on the **SimpleTopic** in the list, then **Publish message** in the top right.
+5. Enter any text you'd like in message body, then click **Publish message**.
+6. Go back to the Lambda console, find your application again and click it.
+7. Select **snsPayloadLogger** in the **Resources** table.
+8. On the new page, select the **Monitoring** tab, then click **View Logs in CloudWatch**, which will take you to the CloudWatch Logs console.
+9. Click on the latest log stream entry, and you will find your log statement.
+
+## Add a resource to your application
+
+The application template uses the AWS Cloud Development Kit (AWS CDK) to define application resources. AWS CDK is an open source software development framework that you can use to model and provision your cloud application resources using familiar programming languages. It provides a library of high-level constructs that simplify resource creation, and an interface for working with CloudFormation resource types directly when needed. When you build an AWS CDK project, the output is a CloudFormation template that defines your application.
+
+The application's resources are defined in `cdk/lib/cdk-stack.ts`. To add a destination to your application, add `@aws-cdk/aws-sqs` and `@aws-cdk/aws-lambda-destinations` to `cdk/package.json`.
+
+```json
+{
+    ...
+    "dependencies": {
+        ...
+        "@aws-cdk/aws-lambda": "^1.31.0",
+        "@aws-cdk/aws-lambda-destinations": "^1.31.0",
+        "@aws-cdk/aws-sqs": "^1.31.0",
+        ...
+    }
+}
+```
+
+Then import the `@aws-cdk/aws-sqs` module and define a `Queue` resource in the class constructor.
+
+**cdk/lib/cdk-stack.ts**
+```typescript
+import * as sns from '@aws-cdk/aws-sns';
+import { Queue } from '@aws-cdk/aws-sqs';
+...
+
+export class CdkStack extends Stack {
+    constructor(scope: App, id: string, props: StackProps) {
+        super(scope, id, props);
+
+        new CfnParameter(this, 'AppId');
+        // Lambda destination
+        const destination = new Queue(this, 'DestinationQueue');
+        ...
+```
+
+The destination is a location for Lambda to send events that could not be processed. It's only used if you invoke your function asynchronously, but it's useful here to show how you can modify your application's resources and function configuration.
+
+Commit the change and push.
+
+```bash
+my-application$ git commit -am "Add destination queue."
+my-application$ git push
+```
+
+**To see how the pipeline processes and deploys the change**
+
+1. Open the [Applications](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Deployments**.
+
+When the deployment is complete, view the application resources on the **Overview** tab to see the new resource.
+
+## Update the permissions boundary
+
+The sample application applies a **permissions boundary** to its function's execution role. The permissions boundary limits the permissions that you can add to the function's role. Without the boundary, users with write access to the project repository could modify the project template to give the function permission to access resources and services outside of the scope of the sample application.
+
+In order for the function to use the queue that you added in the previous step, you must extend the permissions boundary. The Lambda console detects resources that aren't in the permissions boundary and provides an updated policy that you can use to update it.
+
+**To update the application's permissions boundary**
+
+1. Open the [Applications](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Edit permissions boundary**.
+1. Follow the instructions shown to update the boundary to allow access to the new queue.
+
+## Update the function configuration
+
+Now you can grant the function permission to access the queue and configure the destinations setting.
+
+In the function's properties in `cdk/lib/cdk-stack.ts`, import the `@aws-cdk/aws-lambda-destinations` module and add an `SqsDestination` resource to the **onFailure** destinations configuration.
+
+```typescript
+import { SqsDestination } from '@aws-cdk/aws-lambda-destinations';
+import * as s3 from '@aws-cdk/aws-s3';
+import * as sns from '@aws-cdk/aws-sns';
+...
+
+// This is a Lambda function config associated with the source code: sns-payload-logger.js
+const snsPayloadLoggerFunction = new lambda.Function(this, 'snsPayloadLogger', {
+    description: 'A Lambda function that logs the payload of messages sent to an associated SNS topic.',
+    handler: 'src/handlers/sns-payload-logger.snsPayloadLoggerHandler',
+    runtime: lambda.Runtime.NODEJS_14_X,
+    code: lambda.Code.fromBucket(
+        s3.Bucket.fromBucketName(this, 'ArtifactBucket', artifactBucket),
+        artifactKey,
+    ),
+    events: [new SnsEventSource(topic)],
+    onFailure: new SqsDestination(destination),
+});
+```
+
+Commit and push the change. When the deployment is complete, view the function in the console to see the updated configuration that specifies the destination.
+
+## Build and test locally
+
+The AWS SAM command line interface (CLI) is an extension of the AWS CLI that adds functionality for building and testing Lambda applications. It uses Docker to run your functions in an Amazon Linux environment that matches Lambda. It can also emulate your application's build environment and API.
+
+If you prefer to use an integrated development environment (IDE) to build and test your application, you can use the AWS Toolkit.
+The AWS Toolkit is an open-source plugin for popular IDEs that uses the AWS SAM CLI to build and deploy serverless applications on AWS. The AWS Toolkit also adds step-through debugging for Lambda function code.
+
+To get started, see the following:
+
+* [PyCharm](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [IntelliJ](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [VS Code](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html)
+* [Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/welcome.html)
+
+To use the AWS SAM CLI with this sample, you need the following tools:
+
+* AWS CLI - [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) and [configure it with your AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
+* AWS SAM CLI - [Install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html).
+* Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community).
+
+Compile your AWS CDK app and create a AWS CloudFormation template
+
+```bash
+my-application$ cd cdk
+cdk$ export S3_BUCKET=mockBucket
+cdk$ cdk synth --no-staging > ../template.yaml
+```
+
+Find the logical ID for your Lambda function in `template.yaml`. It will look like *snsPayloadLogger12345678*, where *12345678* represents an 8-character unique ID that the AWS CDK generates for all resources. The line right after it should look like `Type: AWS::Lambda::Function`.
+
+Test a single function by invoking it directly with a test event. An event is a JSON document that represents the input that the function receives from the event source. Test events are included in the `events` folder in this project.
+
+Although functions in `template.yaml` are specified to have deployment package in S3, AWS SAM CLI assumes the source code is in the same local directory as `template.yaml`.
+
+Run functions locally and invoke them with the `sam local invoke` command.
+
+```bash
+my-application$ sam local invoke snsPayloadLogger12345678 --event events/event-sns.json
+```
+
+## Unit tests
+
+Requirements:
+
+* Node.js - [Install Node.js 14.x](https://nodejs.org/en/), including the npm package management tool.
+
+Tests are defined in the \_\_tests__ folder in this project. Use `npm` to install the [Jest test framework](https://jestjs.io/) and run unit tests.
+
+```bash
+my-application$ npm install
+my-application$ npm run test
+```
+
+## Resources
+
+For an introduction to the AWS CDK specification, see the [AWS CDK Developer Guide](https://docs.aws.amazon.com/cdk/latest/guide/home.html).
+
+Next, you can use the AWS Serverless Application Repository to deploy ready-to-use apps that go beyond Hello World samples and learn how authors developed their applications. For more information, see the [AWS Serverless Application Repository main page](https://aws.amazon.com/serverless/serverlessrepo/) and the [AWS Serverless Application Repository Developer Guide](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/what-is-serverlessrepo.html).

--- a/nodejs14.x/notifications-processing/cdk/__tests__/unit/handlers/sns-payload-logger.test.js
+++ b/nodejs14.x/notifications-processing/cdk/__tests__/unit/handlers/sns-payload-logger.test.js
@@ -1,0 +1,29 @@
+// Import all functions from sns-payload-logger.js
+const snsPayloadLogger = require('../../../src/handlers/sns-payload-logger.js');
+
+describe('Test for sns-payload-logger', () => {
+    // This test invokes the sns-payload-logger Lambda function and verifies that the received payload is logged
+    it('Verifies the payload is logged', async () => {
+        // Mock console.log statements so we can verify them. For more information, see
+        // https://jestjs.io/docs/en/mock-functions.html
+        console.log = jest.fn();
+
+        // Create a sample payload with SNS message format
+        const payload = {
+            Records: [{
+                Sns: {
+                    Message: 'This is a notification from SNS',
+                    Subject: 'SNS Notification',
+                    TopicArn: 'arn:aws:sns:us-west-2:123456789012:SimpleTopic',
+                },
+            }],
+        };
+
+        await snsPayloadLogger.snsPayloadLoggerHandler(payload, null);
+
+        // Verify that console.log has been called with the expected payload
+        payload.Records.forEach(({ Sns }, i) => {
+            expect(console.log).toHaveBeenNthCalledWith(i + 1, JSON.stringify(Sns));
+        });
+    });
+});

--- a/nodejs14.x/notifications-processing/cdk/buildspec.yml
+++ b/nodejs14.x/notifications-processing/cdk/buildspec.yml
@@ -1,0 +1,32 @@
+version: 0.2
+phases:
+  install:
+    commands:
+      # Install all dependencies (including dependencies for running tests)
+      - npm install
+      # Install CDK dependencies
+      - cd cdk
+      - npm install -g aws-cdk
+      - npm install
+      - cd ..
+  pre_build:
+    commands:
+      # Discover and run unit tests in the '__tests__' directory
+      - npm run test
+      # Remove all dependencies not needed for the Lambda deployment package (the packages from devDependencies in package.json)
+      - npm prune --production
+      # Copy artifacts to a separate folder
+      - mkdir function-code
+      - cp -r src node_modules function-code
+  build:
+    commands:
+      # Archive Lambda function code and upload it to S3
+      - cd function-code
+      - zip -r function-code.zip .
+      - aws s3 cp function-code.zip s3://$S3_BUCKET/$CODEBUILD_BUILD_ID/
+      # Use AWS CDK to synthesize the application
+      - cd ../cdk
+      - cdk synth > ../template-export.yml
+artifacts:
+  files:
+    - template-export.yml

--- a/nodejs14.x/notifications-processing/cdk/cdk/README.md
+++ b/nodejs14.x/notifications-processing/cdk/cdk/README.md
@@ -1,0 +1,8 @@
+# Useful commands
+
+ * `npm run build`   compile typescript to js
+ * `npm run watch`   watch for changes and compile
+ * `npm run test`    perform the jest unit tests
+ * `cdk deploy`      deploy this stack to your default AWS account/region
+ * `cdk diff`        compare deployed stack with current state
+ * `cdk synth`       emits the synthesized CloudFormation template

--- a/nodejs14.x/notifications-processing/cdk/cdk/bin/cdk.ts
+++ b/nodejs14.x/notifications-processing/cdk/cdk/bin/cdk.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import { App, Aws } from '@aws-cdk/core';
+
+import { CdkStack } from '../lib/cdk-stack';
+import { PermissionsBoundaryAspect } from '../lib/permissions-boundary-aspect';
+
+
+const stack = new CdkStack(new App(), 'CdkStack', { description: 'Lambda-SNS starter project' });
+const { ACCOUNT_ID, PARTITION, REGION, STACK_NAME } = Aws;
+const permissionBoundaryArn = `arn:${PARTITION}:iam::${ACCOUNT_ID}:policy/${STACK_NAME}-${REGION}-PermissionsBoundary`;
+
+// Apply permissions boundary to the stack
+stack.node.applyAspect(new PermissionsBoundaryAspect(permissionBoundaryArn));

--- a/nodejs14.x/notifications-processing/cdk/cdk/cdk.json
+++ b/nodejs14.x/notifications-processing/cdk/cdk/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "npx ts-node bin/cdk.ts"
+}

--- a/nodejs14.x/notifications-processing/cdk/cdk/jest.config.js
+++ b/nodejs14.x/notifications-processing/cdk/cdk/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+    'roots': [
+        '<rootDir>/test'
+    ],
+    testMatch: ['**/*.test.ts'],
+    'transform': {
+        '^.+\\.tsx?$': 'ts-jest'
+    },
+};

--- a/nodejs14.x/notifications-processing/cdk/cdk/lib/cdk-stack.ts
+++ b/nodejs14.x/notifications-processing/cdk/cdk/lib/cdk-stack.ts
@@ -1,0 +1,34 @@
+import * as lambda from '@aws-cdk/aws-lambda';
+import { SnsEventSource } from '@aws-cdk/aws-lambda-event-sources';
+import * as s3 from '@aws-cdk/aws-s3';
+import * as sns from '@aws-cdk/aws-sns';
+import { App, CfnParameter, Stack, StackProps } from '@aws-cdk/core';
+
+
+export class CdkStack extends Stack {
+    constructor(scope: App, id: string, props: StackProps) {
+        super(scope, id, props);
+
+        new CfnParameter(this, 'AppId');
+
+        // The code will be uploaded to this location during the pipeline's build step
+        const artifactBucket = process.env.S3_BUCKET!;
+        const artifactKey = `${process.env.CODEBUILD_BUILD_ID}/function-code.zip`;
+
+        // This is an SNS Topic with all default configuration properties. To learn more about the available options, see
+        // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sns-topic.html
+        const topic = new sns.Topic(this, 'SimpleTopic');
+
+        // This is a Lambda function config associated with the source code: sns-payload-logger.js
+        new lambda.Function(this, 'snsPayloadLoggerFunction', {
+            description: 'A Lambda function that logs the payload of messages sent to an associated SNS topic.',
+            handler: 'src/handlers/sns-payload-logger.snsPayloadLoggerHandler',
+            runtime: lambda.Runtime.NODEJS_14_X,
+            code: lambda.Code.fromBucket(
+                s3.Bucket.fromBucketName(this, 'ArtifactBucket', artifactBucket),
+                artifactKey,
+            ),
+            events: [new SnsEventSource(topic)],
+        });
+    }
+}

--- a/nodejs14.x/notifications-processing/cdk/cdk/lib/permissions-boundary-aspect.ts
+++ b/nodejs14.x/notifications-processing/cdk/cdk/lib/permissions-boundary-aspect.ts
@@ -1,0 +1,18 @@
+import * as iam from '@aws-cdk/aws-iam';
+import { IAspect, IConstruct } from '@aws-cdk/core';
+
+
+export class PermissionsBoundaryAspect implements IAspect {
+    private readonly arn: string;
+
+    constructor(permissionBoundaryArn: string) {
+        this.arn = permissionBoundaryArn;
+    }
+
+    public visit(node: IConstruct): void {
+        if (node instanceof iam.Role) {
+            const roleResource = node.node.findChild('Resource') as iam.CfnRole;
+            roleResource.addPropertyOverride('PermissionsBoundary', this.arn);
+        }
+    }
+}

--- a/nodejs14.x/notifications-processing/cdk/cdk/package.json
+++ b/nodejs14.x/notifications-processing/cdk/cdk/package.json
@@ -1,0 +1,30 @@
+{
+    "name": "lambda-sns-cdk",
+    "version": "0.0.1",
+    "bin": {
+        "cdk": "bin/cdk.js"
+    },
+    "scripts": {
+        "build": "tsc",
+        "watch": "tsc -w",
+        "test": "jest",
+        "cdk": "cdk"
+    },
+    "devDependencies": {
+        "@aws-cdk/assert": "^1.31.0",
+        "@types/jest": "^25.2.1",
+        "@types/node": "^10.17.5",
+        "aws-cdk": "^1.31.0",
+        "jest": "^25.4.0",
+        "ts-jest": "^25.4.0",
+        "ts-node": "^8.9.0",
+        "typescript": "^3.8.3"
+    },
+    "dependencies": {
+        "@aws-cdk/aws-lambda-event-sources": "^1.31.0",
+        "@aws-cdk/aws-sns": "^1.31.0",
+        "@aws-cdk/aws-lambda": "^1.31.0",
+        "@aws-cdk/aws-s3": "^1.31.0",
+        "@aws-cdk/core": "^1.31.0"
+    }
+}

--- a/nodejs14.x/notifications-processing/cdk/cdk/package.json
+++ b/nodejs14.x/notifications-processing/cdk/cdk/package.json
@@ -13,7 +13,7 @@
     "devDependencies": {
         "@aws-cdk/assert": "^1.31.0",
         "@types/jest": "^25.2.1",
-        "@types/node": "^10.17.5",
+        "@types/node": "^14.17.5",
         "aws-cdk": "^1.31.0",
         "jest": "^25.4.0",
         "ts-jest": "^25.4.0",

--- a/nodejs14.x/notifications-processing/cdk/cdk/tsconfig.json
+++ b/nodejs14.x/notifications-processing/cdk/cdk/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "target": "ES2018",
+        "module": "commonjs",
+        "lib": [
+            "es2016",
+            "es2017.object",
+            "es2017.string"
+        ],
+        "declaration": true,
+        "strict": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "noImplicitThis": true,
+        "alwaysStrict": true,
+        "noUnusedLocals": false,
+        "noUnusedParameters": false,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": false,
+        "inlineSourceMap": true,
+        "inlineSources": true,
+        "experimentalDecorators": true,
+        "strictPropertyInitialization": false,
+        "typeRoots": [
+            "./node_modules/@types"
+        ]
+    },
+    "exclude": [
+        "cdk.out"
+    ]
+}

--- a/nodejs14.x/notifications-processing/cdk/events/event-sns.json
+++ b/nodejs14.x/notifications-processing/cdk/events/event-sns.json
@@ -1,0 +1,11 @@
+{
+  "Records": [
+    {
+      "Sns": {
+        "Message": "This is a notification from SNS",
+        "Subject": "SNS Notification",
+        "TopicArn": "arn:aws:sns:us-west-2:123456789012:SimpleTopic"
+      }
+    }
+  ]
+}

--- a/nodejs14.x/notifications-processing/cdk/package.json
+++ b/nodejs14.x/notifications-processing/cdk/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "lambda-sns",
+    "description": "Lambda-SNS starter project",
+    "version": "0.0.1",
+    "private": true,
+    "dependencies": {
+    },
+    "devDependencies": {
+        "jest": "^25.4.0"
+    },
+    "scripts": {
+        "test": "jest"
+    }
+}

--- a/nodejs14.x/notifications-processing/cdk/src/handlers/sns-payload-logger.js
+++ b/nodejs14.x/notifications-processing/cdk/src/handlers/sns-payload-logger.js
@@ -1,0 +1,10 @@
+/**
+ * A Lambda function that logs the payload received from SNS.
+ */
+exports.snsPayloadLoggerHandler = async (event, context) => {
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    event.Records.forEach(({ Sns }) => {
+        console.log(JSON.stringify(Sns));
+    });
+};

--- a/nodejs14.x/notifications-processing/sam/.gitignore
+++ b/nodejs14.x/notifications-processing/sam/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/nodejs14.x/notifications-processing/sam/README.md
+++ b/nodejs14.x/notifications-processing/sam/README.md
@@ -1,0 +1,161 @@
+# Lambda-SNS starter project
+
+This project contains source code and supporting files for the serverless application that you created in the AWS Lambda console. You can update your application at any time by committing and pushing changes to your AWS CodeCommit or GitHub repository.
+
+This project includes the following files and folders:
+
+- src - Code for the application's Lambda function.
+- events - Invocation events that you can use to invoke the function.
+- \_\_tests__ - Unit tests for the application code.
+- template.yml - A SAM template that defines the application's AWS resources.
+- buildspec.yml -  A build specification file that tells AWS CodeBuild how to create a deployment package for the function.
+
+Your Lambda application includes two AWS CloudFormation stacks. The first stack creates the pipeline that builds and deploys your application.
+
+The pipeline creates a second stack that contains your application's resources, including Lambda functions, and an Amazon SNS topic. These resources are defined in the `template.yml` file in this project. You can update the template to add AWS resources through the same deployment process that updates your application code. You can view those resources in the **Resources** section of the application overview in the Lambda console.
+
+For a full list of possible operations, see the [AWS Lambda Applications documentation](https://docs.aws.amazon.com/lambda/latest/dg/deploying-lambda-apps.html).
+
+## Try the application out
+
+1. Go to the Lambda console.
+2. Select **Applications** and select the one you created.
+3. Select **SimpleTopic** in **Resources** table, which will redirect you to the SNS console.
+4. Click on the **SimpleTopic** in the list, then **Publish message** in the top right.
+5. Enter any text you'd like in message body, then click **Publish message**.
+6. Go back to the Lambda console, find your application again and click it.
+7. Select **snsPayloadLoggerFunction** in the **Resources** table.
+8. On the new page, select the **Monitoring** tab, then click **View Logs in CloudWatch**, which will take you to the CloudWatch Logs console.
+9. Click on the latest log stream entry, and you will find your log statement.
+
+## Add a resource to your application
+
+The application template uses the AWS Serverless Application Model (AWS SAM) to define application resources. AWS SAM is an extension of AWS CloudFormation with a simpler syntax for configuring common serverless application resources, such as functions, triggers, and APIs. For resources that aren't included in the [AWS SAM specification](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md), you can use the standard [AWS CloudFormation resource types](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html).
+
+Update `template.yml` to add a dead-letter queue to your application. In the **Resources** section, add a resource named **MyQueue** with the type **AWS::SQS::Queue**.
+
+```
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+```
+
+The dead-letter queue is a location for Lambda to send events that could not be processed. It's only used if you invoke your function asynchronously, but it's useful here to show how you can modify your application's resources and function configuration.
+
+Commit the change and push.
+
+```bash
+my-application$ git commit -am "Add dead-letter queue."
+my-application$ git push
+```
+
+**To see how the pipeline processes and deploys the change**
+
+1. Open the [**Applications**](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Deployments**.
+
+When the deployment completes, view the application resources on the **Overview** tab to see the new resource.
+
+## Update the permissions boundary
+
+The sample application applies a **permissions boundary** to its function's execution role. The permissions boundary limits the permissions that you can add to the function's role. Without the boundary, users with write access to the project repository could modify the project template to give the function permission to access resources and services outside of the scope of the sample application.
+
+In order for the function to use the queue that you added in the previous step, you must extend the permissions boundary. The Lambda console detects resources that aren't in the permissions boundary and provides an updated policy that you can use to update it.
+
+**To update the application's permissions boundary**
+
+1. Open the [**Applications**](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Edit permissions boundary**.
+1. Follow the instructions shown to update the boundary to allow access to the new queue.
+
+## Update the function configuration
+
+Now you can grant the function permission to access the queue and configure the dead-letter queue setting.
+
+In the function's properties in `template.yml`, add the **DeadLetterQueue** configuration. Under Policies, add **SQSSendMessagePolicy**. **SQSSendMessagePolicy** is a [policy template](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-policy-templates.html) that grants the function permission to send messages to a queue.
+
+```
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+  snsPayloadLoggerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: src/handlers/sns-payload-logger.snsPayloadLoggerHandler
+      Runtime: nodejs14.x
+      Description: A Lambda function that logs the payload of messages sent to an associated SNS topic.
+      MemorySize: 128
+      Timeout: 60
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !GetAtt MyQueue.Arn
+      Policies:
+        - SQSSendMessagePolicy:
+            QueueName: !GetAtt MyQueue.QueueName
+        - AWSLambdaBasicExecutionRole
+      Events:
+        SimpleTopicEvent:
+          Type: SNS
+          Properties:
+            Topic: !Ref SimpleTopic
+```
+
+Commit and push the change. When the deployment completes, view the function in the console to see the updated configuration that specifies the dead-letter queue.
+
+## Build and test locally
+
+The AWS SAM command line interface (CLI) is an extension of the AWS CLI that adds functionality for building and testing Lambda applications. It uses Docker to run your functions in an Amazon Linux environment that matches Lambda. It can also emulate your application's build environment and API.
+
+If you prefer to use an integrated development environment (IDE) to build and test your application, you can use the AWS Toolkit.
+The AWS Toolkit is an open-source plugin for popular IDEs that uses the AWS SAM CLI to build and deploy serverless applications on AWS. The AWS Toolkit also adds step-through debugging for Lambda function code.
+
+To get started, see the following:
+
+* [PyCharm](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [IntelliJ](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [VS Code](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html)
+* [Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/welcome.html)
+
+To use the AWS SAM CLI with this sample, you need the following tools:
+
+* AWS CLI - [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) and [configure it with your AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
+* AWS SAM CLI - [Install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html).
+* Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community).
+
+Build your application with the `sam build` command.
+
+```bash
+my-application$ sam build -m package.json
+```
+
+The AWS SAM CLI installs dependencies that are defined in `package.json`, creates a deployment package, and saves its contents in the `.aws-sam/build` folder.
+
+Test a single function by invoking it directly with a test event. An event is a JSON document that represents the input that the function receives from the event source. Test events are included in the `events` folder in this project.
+
+Run functions locally and invoke them with the `sam local invoke` command.
+
+```bash
+my-application$ sam local invoke snsPayloadLoggerFunction --event events/event-sns.json
+```
+
+## Unit tests
+
+Requirements:
+
+* Node.js - [Install Node.js 14.x](https://nodejs.org/en/), including the npm package management tool.
+
+Tests are defined in the \_\_tests__ folder in this project. Use `npm` to install the [Jest test framework](https://jestjs.io/) and run unit tests.
+
+```bash
+my-application$ npm install
+my-application$ npm run test
+```
+
+## Resources
+
+For an introduction to the AWS SAM specification, the AWS SAM CLI, and serverless application concepts, see the [AWS SAM Developer Guide](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html).
+
+Next, you can use the AWS Serverless Application Repository to deploy ready-to-use apps that go beyond Hello World samples and learn how authors developed their applications. For more information, see the [AWS Serverless Application Repository main page](https://aws.amazon.com/serverless/serverlessrepo/) and the [AWS Serverless Application Repository Developer Guide](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/what-is-serverlessrepo.html).

--- a/nodejs14.x/notifications-processing/sam/__tests__/unit/handlers/sns-payload-logger.test.js
+++ b/nodejs14.x/notifications-processing/sam/__tests__/unit/handlers/sns-payload-logger.test.js
@@ -1,0 +1,29 @@
+// Import all functions from sns-payload-logger.js
+const snsPayloadLogger = require('../../../src/handlers/sns-payload-logger.js');
+
+describe('Test for sns-payload-logger', () => {
+    // This test invokes the sns-payload-logger Lambda function and verifies that the received payload is logged
+    it('Verifies the payload is logged', async () => {
+        // Mock console.log statements so we can verify them. For more information, see
+        // https://jestjs.io/docs/en/mock-functions.html
+        console.log = jest.fn();
+
+        // Create a sample payload with SNS message format
+        const payload = {
+            Records: [{
+                Sns: {
+                    Message: 'This is a notification from SNS',
+                    Subject: 'SNS Notification',
+                    TopicArn: 'arn:aws:sns:us-west-2:123456789012:SimpleTopic',
+                },
+            }],
+        };
+
+        await snsPayloadLogger.snsPayloadLoggerHandler(payload, null);
+
+        // Verify that console.log has been called with the expected payload
+        payload.Records.forEach(({ Sns }, i) => {
+            expect(console.log).toHaveBeenNthCalledWith(i + 1, JSON.stringify(Sns));
+        });
+    });
+});

--- a/nodejs14.x/notifications-processing/sam/buildspec.yml
+++ b/nodejs14.x/notifications-processing/sam/buildspec.yml
@@ -1,0 +1,22 @@
+version: 0.2
+phases:
+  install:
+    commands:
+      # Install all dependencies (including dependencies for running tests)
+      - npm install
+  pre_build:
+    commands:
+      # Discover and run unit tests in the '__tests__' directory
+      - npm run test
+      # Remove all unit tests to reduce the size of the package that will be ultimately uploaded to Lambda
+      - rm -rf ./__tests__
+      # Remove all dependencies not needed for the Lambda deployment package (the packages from devDependencies in package.json)
+      - npm prune --production
+  build:
+    commands:
+      # Use AWS SAM to package the application by using AWS CloudFormation
+      - aws cloudformation package --template template.yml --s3-bucket $S3_BUCKET --output-template template-export.yml
+artifacts:
+  type: zip
+  files:
+    - template-export.yml

--- a/nodejs14.x/notifications-processing/sam/events/event-sns.json
+++ b/nodejs14.x/notifications-processing/sam/events/event-sns.json
@@ -1,0 +1,11 @@
+{
+  "Records": [
+    {
+      "Sns": {
+        "Message": "This is a notification from SNS",
+        "Subject": "SNS Notification",
+        "TopicArn": "arn:aws:sns:us-west-2:123456789012:SimpleTopic"
+      }
+    }
+  ]
+}

--- a/nodejs14.x/notifications-processing/sam/package.json
+++ b/nodejs14.x/notifications-processing/sam/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "lambda-sns",
+    "description": "Lambda-SNS starter project",
+    "version": "0.0.1",
+    "private": true,
+    "dependencies": {
+    },
+    "devDependencies": {
+        "jest": "^24.7.1"
+    },
+    "scripts": {
+        "test": "jest"
+    }
+}

--- a/nodejs14.x/notifications-processing/sam/src/handlers/sns-payload-logger.js
+++ b/nodejs14.x/notifications-processing/sam/src/handlers/sns-payload-logger.js
@@ -1,0 +1,10 @@
+/**
+ * A Lambda function that logs the payload received from SNS.
+ */
+exports.snsPayloadLoggerHandler = async (event, context) => {
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    event.Records.forEach(({ Sns }) => {
+        console.log(JSON.stringify(Sns));
+    });
+};

--- a/nodejs14.x/notifications-processing/sam/template.yml
+++ b/nodejs14.x/notifications-processing/sam/template.yml
@@ -1,0 +1,55 @@
+# This is the SAM template that represents the architecture of your serverless application
+# https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-template-basics.html
+
+# The AWSTemplateFormatVersion identifies the capabilities of the template
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/format-version-structure.html
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Lambda-SNS starter project
+
+# Transform section specifies one or more macros that AWS CloudFormation uses to process your template
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-section-structure.html
+Transform: AWS::Serverless-2016-10-31
+
+# Shared configuration for all resources, more in
+# https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
+Globals:
+  Function:
+    # The PermissionsBoundary allows users to safely develop with their function's permissions constrained
+    # to their current application. All the functions and roles in this application have to include it and
+    # it has to be manually updated when you add resources to your application.
+    # More information in https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html
+    PermissionsBoundary: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/${AppId}-${AWS::Region}-PermissionsBoundary'
+
+Parameters:
+  AppId:
+    Type: String
+
+# Resources declares the AWS resources that you want to include in the stack
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html
+Resources:
+  # Each Lambda function is defined by properties:
+  # https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+
+  # This is a Lambda function config associated with the source code: sns-payload-logger.js
+  snsPayloadLoggerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: src/handlers/sns-payload-logger.snsPayloadLoggerHandler
+      Runtime: nodejs14.x
+      Description: A Lambda function that logs the payload of messages sent to an associated SNS topic.
+      MemorySize: 128
+      Timeout: 60
+      Policies:
+        # Give Lambda basic execution Permission to the snsPayloadLogger
+        - AWSLambdaBasicExecutionRole
+      Events:
+        SimpleTopicEvent:
+          Type: SNS
+          Properties:
+            Topic: !Ref SimpleTopic
+  # This is an SNS Topic with all default configuration properties. To learn more about the available options, see
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sns-topic.html
+  SimpleTopic:
+    Type: AWS::SNS::Topic

--- a/nodejs14.x/queue-processing/cdk/.gitignore
+++ b/nodejs14.x/queue-processing/cdk/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/nodejs14.x/queue-processing/cdk/LICENSE
+++ b/nodejs14.x/queue-processing/cdk/LICENSE
@@ -1,0 +1,14 @@
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/nodejs14.x/queue-processing/cdk/README.md
+++ b/nodejs14.x/queue-processing/cdk/README.md
@@ -1,0 +1,179 @@
+# Lambda-SQS starter project
+
+This project contains source code and supporting files for the serverless application that you created in the AWS Lambda console. You can update your application at any time by committing and pushing changes to your AWS CodeCommit or GitHub repository.
+
+This project includes the following files and folders:
+
+- src - Code for the application's Lambda function.
+- events - Invocation events that you can use to invoke the function.
+- \_\_tests__ - Unit tests for the application code.
+- cdk - The CDK model that defines the application's AWS resources.
+- buildspec.yml -  A build specification file that tells AWS CodeBuild how to create a deployment package for the function.
+
+Your Lambda application includes two AWS CloudFormation stacks. The first stack creates the pipeline that builds and deploys your application.
+
+The pipeline creates a second stack that contains your application's resources, including Lambda functions and an Amazon SQS queue. These resources are defined in the `cdk/lib/cdk-stack.ts` file in this project. You can update the CDK model to add AWS resources through the same deployment process that updates your application code. You can view those resources in the **Resources** section of the application overview in the Lambda console.
+
+For a full list of possible operations, see the [AWS Lambda Applications documentation](https://docs.aws.amazon.com/lambda/latest/dg/deploying-lambda-apps.html).
+
+## Try the application out
+
+1. Go to the SQS console.
+2. Select the queue prefixed with your application name.
+3. Click **Queue Actions > Send a Message** in the top left.
+4. Enter any text you'd like, then click **Send Message**.
+5. Go back to the Lambda console, find your application again and click it.
+6. Select **sqsPayloadLogger** in the **Resources** table.
+7. On the new page, select the **Monitoring** tab, then click **View Logs in CloudWatch**, which will take you to the CloudWatch Logs console.
+8. Click on the latest log stream entry, and you will find your log statement.
+
+## Add a resource to your application
+
+The application template uses the AWS Cloud Development Kit (AWS CDK) to define application resources. AWS CDK is an open source software development framework that you can use to model and provision your cloud application resources using familiar programming languages. It provides a library of high-level constructs that simplify resource creation, and an interface for working with CloudFormation resource types directly when needed. When you build an AWS CDK project, the output is a CloudFormation template that defines your application.
+
+The application's resources are defined in `cdk/lib/cdk-stack.ts`. To add a destination to your application, add `@aws-cdk/aws-lambda-destinations` to `cdk/package.json`.
+
+```json
+{
+    ...
+    "dependencies": {
+        ...
+        "@aws-cdk/aws-lambda": "^1.31.0",
+        "@aws-cdk/aws-lambda-destinations": "^1.31.0",
+        "@aws-cdk/aws-sqs": "^1.31.0",
+        ...
+    }
+}
+```
+
+Then define another `Queue` resource in the class constructor.
+
+**cdk/lib/cdk-stack.ts**
+```typescript
+export class CdkStack extends Stack {
+    constructor(scope: App, id: string, props: StackProps) {
+        super(scope, id, props);
+
+        new CfnParameter(this, 'AppId');
+        // Lambda destination
+        const destination = new sqs.Queue(this, 'DestinationQueue');
+        ...
+```
+
+The destination is a location for Lambda to send events that could not be processed. It's only used if you invoke your function asynchronously, but it's useful here to show how you can modify your application's resources and function configuration.
+
+Commit the change and push.
+
+```bash
+my-application$ git commit -am "Add destination queue."
+my-application$ git push
+```
+
+**To see how the pipeline processes and deploys the change**
+
+1. Open the [Applications](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Deployments**.
+
+When the deployment is complete, view the application resources on the **Overview** tab to see the new resource.
+
+## Update the permissions boundary
+
+The sample application applies a **permissions boundary** to its function's execution role. The permissions boundary limits the permissions that you can add to the function's role. Without the boundary, users with write access to the project repository could modify the project template to give the function permission to access resources and services outside of the scope of the sample application.
+
+In order for the function to use the queue that you added in the previous step, you must extend the permissions boundary. The Lambda console detects resources that aren't in the permissions boundary and provides an updated policy that you can use to update it.
+
+**To update the application's permissions boundary**
+
+1. Open the [Applications](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Edit permissions boundary**.
+1. Follow the instructions shown to update the boundary to allow access to the new queue.
+
+## Update the function configuration
+
+Now you can grant the function permission to access the queue and configure the destinations setting.
+
+In the function's properties in `cdk/lib/cdk-stack.ts`, import the `@aws-cdk/aws-lambda-destinations` module and add an `SqsDestination` resource to the **onFailure** destinations configuration.
+
+```typescript
+import { SqsDestination } from '@aws-cdk/aws-lambda-destinations';
+import * as s3 from '@aws-cdk/aws-s3';
+import * as sqs from '@aws-cdk/aws-sqs';
+...
+
+// This is a Lambda function config associated with the source code: sqs-payload-logger.js
+const sqsPayloadLoggerFunction = new lambda.Function(this, 'sqsPayloadLogger', {
+    description: 'A Lambda function that logs the payload of messages sent to an associated SQS queue.',
+    handler: 'src/handlers/sqs-payload-logger.sqsPayloadLoggerHandler',
+    runtime: lambda.Runtime.NODEJS_14_X,
+    code: lambda.Code.fromBucket(
+        s3.Bucket.fromBucketName(this, 'ArtifactBucket', artifactBucket),
+        artifactKey,
+    ),
+    timeout: Duration.seconds(25), // Chosen to be less than the default SQS Visibility Timeout of 30 seconds
+    events: [new SqsEventSource(queue)],
+    onFailure: new SqsDestination(destination),
+});
+```
+
+Commit and push the change. When the deployment is complete, view the function in the console to see the updated configuration that specifies the destination.
+
+## Build and test locally
+
+The AWS SAM command line interface (CLI) is an extension of the AWS CLI that adds functionality for building and testing Lambda applications. It uses Docker to run your functions in an Amazon Linux environment that matches Lambda. It can also emulate your application's build environment and API.
+
+If you prefer to use an integrated development environment (IDE) to build and test your application, you can use the AWS Toolkit.
+The AWS Toolkit is an open-source plugin for popular IDEs that uses the AWS SAM CLI to build and deploy serverless applications on AWS. The AWS Toolkit also adds step-through debugging for Lambda function code.
+
+To get started, see the following:
+
+* [PyCharm](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [IntelliJ](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [VS Code](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html)
+* [Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/welcome.html)
+
+To use the AWS SAM CLI with this sample, you need the following tools:
+
+* AWS CLI - [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) and [configure it with your AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
+* AWS SAM CLI - [Install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html).
+* Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community).
+
+Compile your AWS CDK app and create a AWS CloudFormation template
+
+```bash
+my-application$ cd cdk
+cdk$ export S3_BUCKET=mockBucket
+cdk$ cdk synth --no-staging > ../template.yaml
+```
+
+Find the logical ID for your Lambda function in `template.yaml`. It will look like *sqsPayloadLogger12345678*, where *12345678* represents an 8-character unique ID that the AWS CDK generates for all resources. The line right after it should look like `Type: AWS::Lambda::Function`.
+
+Test a single function by invoking it directly with a test event. An event is a JSON document that represents the input that the function receives from the event source. Test events are included in the `events` folder in this project.
+
+Although functions in `template.yaml` are specified to have deployment package in S3, AWS SAM CLI assumes the source code is in the same local directory as `template.yaml`.
+
+Run functions locally and invoke them with the `sam local invoke` command.
+
+```bash
+my-application$ sam local invoke sqsPayloadLogger12345678 --event events/event-sqs.json
+```
+
+## Unit tests
+
+Requirements:
+
+* Node.js - [Install Node.js 14.x](https://nodejs.org/en/), including the npm package management tool.
+
+Tests are defined in the \_\_tests__ folder in this project. Use `npm` to install the [Jest test framework](https://jestjs.io/) and run unit tests.
+
+```bash
+my-application$ npm install
+my-application$ npm run test
+```
+
+## Resources
+
+For an introduction to the AWS CDK specification, see the [AWS CDK Developer Guide](https://docs.aws.amazon.com/cdk/latest/guide/home.html).
+
+Next, you can use the AWS Serverless Application Repository to deploy ready-to-use apps that go beyond Hello World samples and learn how authors developed their applications. For more information, see the [AWS Serverless Application Repository main page](https://aws.amazon.com/serverless/serverlessrepo/) and the [AWS Serverless Application Repository Developer Guide](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/what-is-serverlessrepo.html).

--- a/nodejs14.x/queue-processing/cdk/__tests__/unit/handlers/sqs-payload-logger.test.js
+++ b/nodejs14.x/queue-processing/cdk/__tests__/unit/handlers/sqs-payload-logger.test.js
@@ -1,0 +1,40 @@
+// Import all functions from sqs-payload-logger.js
+const sqsPayloadLogger = require('../../../src/handlers/sqs-payload-logger.js');
+
+describe('Test for sqs-payload-logger', () => {
+    // This test invokes the sqs-payload-logger Lambda function and verifies that the received payload is logged
+    it('Verifies the payload is logged', async () => {
+        // Mock console.log statements so we can verify them. For more information, see
+        // https://jestjs.io/docs/en/mock-functions.html
+        console.log = jest.fn();
+
+        // Create a sample payload with SQS message format
+        const payload = {
+            Records: [
+                {
+                    messageId: '19dd0b57-b21e-4ac1-bd88-01bbb068cb78',
+                    receiptHandle: 'MessageReceiptHandle',
+                    body: 'Hello from SQS!',
+                    attributes: {
+                        ApproximateReceiveCount: '1',
+                        SentTimestamp: '1523232000000',
+                        SenderId: '012345678910',
+                        ApproximateFirstReceiveTimestamp: '1523232000001',
+                    },
+                    messageAttributes: {},
+                    md5OfBody: '7b270e59b47ff90a553787216d55d91d',
+                    eventSource: 'aws:sqs',
+                    eventSourceARN: 'arn:aws:sqs:us-west-2:012345678910:SimpleQueue',
+                    awsRegion: 'us-west-2',
+                },
+            ],
+        };
+
+        await sqsPayloadLogger.sqsPayloadLoggerHandler(payload, null);
+
+        // Verify that console.log has been called with the expected payload
+        payload.Records.forEach((record, i) => {
+            expect(console.log).toHaveBeenNthCalledWith(i + 1, JSON.stringify(record));
+        });
+    });
+});

--- a/nodejs14.x/queue-processing/cdk/buildspec.yml
+++ b/nodejs14.x/queue-processing/cdk/buildspec.yml
@@ -1,0 +1,32 @@
+version: 0.2
+phases:
+  install:
+    commands:
+      # Install all dependencies (including dependencies for running tests)
+      - npm install
+      # Install CDK dependencies
+      - cd cdk
+      - npm install -g aws-cdk
+      - npm install
+      - cd ..
+  pre_build:
+    commands:
+      # Discover and run unit tests in the '__tests__' directory
+      - npm run test
+      # Remove all dependencies not needed for the Lambda deployment package (the packages from devDependencies in package.json)
+      - npm prune --production
+      # Copy artifacts to a separate folder
+      - mkdir function-code
+      - cp -r src node_modules function-code
+  build:
+    commands:
+      # Archive Lambda function code and upload it to S3
+      - cd function-code
+      - zip -r function-code.zip .
+      - aws s3 cp function-code.zip s3://$S3_BUCKET/$CODEBUILD_BUILD_ID/
+      # Use AWS CDK to synthesize the application
+      - cd ../cdk
+      - cdk synth > ../template-export.yml
+artifacts:
+  files:
+    - template-export.yml

--- a/nodejs14.x/queue-processing/cdk/cdk/README.md
+++ b/nodejs14.x/queue-processing/cdk/cdk/README.md
@@ -1,0 +1,8 @@
+# Useful commands
+
+ * `npm run build`   compile typescript to js
+ * `npm run watch`   watch for changes and compile
+ * `npm run test`    perform the jest unit tests
+ * `cdk deploy`      deploy this stack to your default AWS account/region
+ * `cdk diff`        compare deployed stack with current state
+ * `cdk synth`       emits the synthesized CloudFormation template

--- a/nodejs14.x/queue-processing/cdk/cdk/bin/cdk.ts
+++ b/nodejs14.x/queue-processing/cdk/cdk/bin/cdk.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import { App, Aws } from '@aws-cdk/core';
+
+import { CdkStack } from '../lib/cdk-stack';
+import { PermissionsBoundaryAspect } from '../lib/permissions-boundary-aspect';
+
+
+const stack = new CdkStack(new App(), 'CdkStack', { description: 'Lambda-SQS starter project' });
+const { ACCOUNT_ID, PARTITION, REGION, STACK_NAME } = Aws;
+const permissionBoundaryArn = `arn:${PARTITION}:iam::${ACCOUNT_ID}:policy/${STACK_NAME}-${REGION}-PermissionsBoundary`;
+
+// Apply permissions boundary to the stack
+stack.node.applyAspect(new PermissionsBoundaryAspect(permissionBoundaryArn));

--- a/nodejs14.x/queue-processing/cdk/cdk/cdk.json
+++ b/nodejs14.x/queue-processing/cdk/cdk/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "npx ts-node bin/cdk.ts"
+}

--- a/nodejs14.x/queue-processing/cdk/cdk/jest.config.js
+++ b/nodejs14.x/queue-processing/cdk/cdk/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+    'roots': [
+        '<rootDir>/test'
+    ],
+    testMatch: ['**/*.test.ts'],
+    'transform': {
+        '^.+\\.tsx?$': 'ts-jest'
+    },
+};

--- a/nodejs14.x/queue-processing/cdk/cdk/lib/cdk-stack.ts
+++ b/nodejs14.x/queue-processing/cdk/cdk/lib/cdk-stack.ts
@@ -1,0 +1,35 @@
+import * as lambda from '@aws-cdk/aws-lambda';
+import { SqsEventSource } from '@aws-cdk/aws-lambda-event-sources';
+import * as s3 from '@aws-cdk/aws-s3';
+import * as sqs from '@aws-cdk/aws-sqs';
+import { App, CfnParameter, Duration, Stack, StackProps } from '@aws-cdk/core';
+
+
+export class CdkStack extends Stack {
+    constructor(scope: App, id: string, props: StackProps) {
+        super(scope, id, props);
+
+        new CfnParameter(this, 'AppId');
+
+        // The code will be uploaded to this location during the pipeline's build step
+        const artifactBucket = process.env.S3_BUCKET!;
+        const artifactKey = `${process.env.CODEBUILD_BUILD_ID}/function-code.zip`;
+
+        // This is an SQS queue with all default configuration properties. To learn more about the available options, see
+        // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html
+        const queue = new sqs.Queue(this, 'SimpleQueue');
+
+        // This is a Lambda function config associated with the source code: sqs-payload-logger.js
+        new lambda.Function(this, 'sqsPayloadLogger', {
+            description: 'A Lambda function that logs the payload of messages sent to an associated SQS queue.',
+            handler: 'src/handlers/sqs-payload-logger.sqsPayloadLoggerHandler',
+            runtime: lambda.Runtime.NODEJS_14_X,
+            code: lambda.Code.fromBucket(
+                s3.Bucket.fromBucketName(this, 'ArtifactBucket', artifactBucket),
+                artifactKey,
+            ),
+            timeout: Duration.seconds(25), // Chosen to be less than the default SQS Visibility Timeout of 30 seconds
+            events: [new SqsEventSource(queue)],
+        });
+    }
+}

--- a/nodejs14.x/queue-processing/cdk/cdk/lib/permissions-boundary-aspect.ts
+++ b/nodejs14.x/queue-processing/cdk/cdk/lib/permissions-boundary-aspect.ts
@@ -1,0 +1,18 @@
+import * as iam from '@aws-cdk/aws-iam';
+import { IAspect, IConstruct } from '@aws-cdk/core';
+
+
+export class PermissionsBoundaryAspect implements IAspect {
+    private readonly arn: string;
+
+    constructor(permissionBoundaryArn: string) {
+        this.arn = permissionBoundaryArn;
+    }
+
+    public visit(node: IConstruct): void {
+        if (node instanceof iam.Role) {
+            const roleResource = node.node.findChild('Resource') as iam.CfnRole;
+            roleResource.addPropertyOverride('PermissionsBoundary', this.arn);
+        }
+    }
+}

--- a/nodejs14.x/queue-processing/cdk/cdk/package.json
+++ b/nodejs14.x/queue-processing/cdk/cdk/package.json
@@ -1,0 +1,30 @@
+{
+    "name": "lambda-sqs-cdk",
+    "version": "0.0.1",
+    "bin": {
+        "cdk": "bin/cdk.js"
+    },
+    "scripts": {
+        "build": "tsc",
+        "watch": "tsc -w",
+        "test": "jest",
+        "cdk": "cdk"
+    },
+    "devDependencies": {
+        "@aws-cdk/assert": "^1.31.0",
+        "@types/jest": "^25.2.1",
+        "@types/node": "^10.17.5",
+        "aws-cdk": "^1.31.0",
+        "jest": "^25.4.0",
+        "ts-jest": "^25.4.0",
+        "ts-node": "^8.9.0",
+        "typescript": "^3.8.3"
+    },
+    "dependencies": {
+        "@aws-cdk/aws-lambda-event-sources": "^1.31.0",
+        "@aws-cdk/aws-sqs": "^1.31.0",
+        "@aws-cdk/aws-lambda": "^1.31.0",
+        "@aws-cdk/aws-s3": "^1.31.0",
+        "@aws-cdk/core": "^1.31.0"
+    }
+}

--- a/nodejs14.x/queue-processing/cdk/cdk/package.json
+++ b/nodejs14.x/queue-processing/cdk/cdk/package.json
@@ -13,7 +13,7 @@
     "devDependencies": {
         "@aws-cdk/assert": "^1.31.0",
         "@types/jest": "^25.2.1",
-        "@types/node": "^10.17.5",
+        "@types/node": "^14.17.5",
         "aws-cdk": "^1.31.0",
         "jest": "^25.4.0",
         "ts-jest": "^25.4.0",

--- a/nodejs14.x/queue-processing/cdk/cdk/tsconfig.json
+++ b/nodejs14.x/queue-processing/cdk/cdk/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "target": "ES2018",
+        "module": "commonjs",
+        "lib": [
+            "es2016",
+            "es2017.object",
+            "es2017.string"
+        ],
+        "declaration": true,
+        "strict": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "noImplicitThis": true,
+        "alwaysStrict": true,
+        "noUnusedLocals": false,
+        "noUnusedParameters": false,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": false,
+        "inlineSourceMap": true,
+        "inlineSources": true,
+        "experimentalDecorators": true,
+        "strictPropertyInitialization": false,
+        "typeRoots": [
+            "./node_modules/@types"
+        ]
+    },
+    "exclude": [
+        "cdk.out"
+    ]
+}

--- a/nodejs14.x/queue-processing/cdk/events/event-sqs.json
+++ b/nodejs14.x/queue-processing/cdk/events/event-sqs.json
@@ -1,0 +1,20 @@
+{
+  "Records": [
+    {
+      "messageId": "19dd0b57-b21e-4ac1-bd88-01bbb068cb78",
+      "receiptHandle": "MessageReceiptHandle",
+      "body": "Hello from SQS!",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1523232000000",
+        "SenderId": "012345678910",
+        "ApproximateFirstReceiveTimestamp": "1523232000001"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "7b270e59b47ff90a553787216d55d91d",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:us-west-2:012345678910:SimpleQueue",
+      "awsRegion": "us-west-2"
+    }
+  ]
+}

--- a/nodejs14.x/queue-processing/cdk/package.json
+++ b/nodejs14.x/queue-processing/cdk/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "lambda-sqs",
+    "description": "Lambda-SQS starter project",
+    "version": "0.0.1",
+    "private": true,
+    "dependencies": {
+    },
+    "devDependencies": {
+        "jest": "^25.4.0"
+    },
+    "scripts": {
+        "test": "jest"
+    }
+}

--- a/nodejs14.x/queue-processing/cdk/src/handlers/sqs-payload-logger.js
+++ b/nodejs14.x/queue-processing/cdk/src/handlers/sqs-payload-logger.js
@@ -1,0 +1,10 @@
+/**
+ * A Lambda function that logs the payload received from SQS.
+ */
+exports.sqsPayloadLoggerHandler = async (event, context) => {
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    event.Records.forEach((record) => {
+        console.log(JSON.stringify(record));
+    });
+};

--- a/nodejs14.x/queue-processing/sam/.gitignore
+++ b/nodejs14.x/queue-processing/sam/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/nodejs14.x/queue-processing/sam/README.md
+++ b/nodejs14.x/queue-processing/sam/README.md
@@ -1,0 +1,160 @@
+# Lambda-SQS starter project
+
+This project contains source code and supporting files for the serverless application that you created in the AWS Lambda console. You can update your application at any time by committing and pushing changes to your AWS CodeCommit or GitHub repository.
+
+This project includes the following files and folders:
+
+- src - Code for the application's Lambda function.
+- events - Invocation events that you can use to invoke the function.
+- \_\_tests__ - Unit tests for the application code.
+- template.yml - A SAM template that defines the application's AWS resources.
+- buildspec.yml -  A build specification file that tells AWS CodeBuild how to create a deployment package for the function.
+
+Your Lambda application includes two AWS CloudFormation stacks. The first stack creates the pipeline that builds and deploys your application.
+
+The pipeline creates a second stack that contains your application's resources, including Lambda functions, and an Amazon SQS queue. These resources are defined in the `template.yml` file in this project. You can update the template to add AWS resources through the same deployment process that updates your application code. You can view those resources in the **Resources** section of the application overview in the Lambda console.
+
+For a full list of possible operations, see the [AWS Lambda Applications documentation](https://docs.aws.amazon.com/lambda/latest/dg/deploying-lambda-apps.html).
+
+## Try the application out
+
+1. Go to the SQS console.
+2. Select the queue prefixed with your application name.
+3. Click **Queue Actions > Send a Message** in the top left.
+4. Enter any text you'd like, then click **Send Message**.
+5. Go back to the Lambda console, find your application again and click it.
+6. Select **sqsPayloadLoggerFunction** in the **Resources** table.
+7. On the new page, select the **Monitoring** tab, then click **View Logs in CloudWatch**, which will take you to the CloudWatch Logs console.
+8. Click on the latest log stream entry, and you will find your log statement.
+
+## Add a resource to your application
+
+The application template uses the AWS Serverless Application Model (AWS SAM) to define application resources. AWS SAM is an extension of AWS CloudFormation with a simpler syntax for configuring common serverless application resources, such as functions, triggers, and APIs. For resources that aren't included in the [AWS SAM specification](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md), you can use the standard [AWS CloudFormation resource types](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html).
+
+Update `template.yml` to add a dead-letter queue to your application. In the **Resources** section, add a resource named **MyQueue** with the type **AWS::SQS::Queue**.
+
+```
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+```
+
+The dead-letter queue is a location for Lambda to send events that could not be processed. It's only used if you invoke your function asynchronously, but it's useful here to show how you can modify your application's resources and function configuration.
+
+Commit the change and push.
+
+```bash
+my-application$ git commit -am "Add dead-letter queue."
+my-application$ git push
+```
+
+**To see how the pipeline processes and deploys the change**
+
+1. Open the [**Applications**](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Deployments**.
+
+When the deployment completes, view the application resources on the **Overview** tab to see the new resource.
+
+## Update the permissions boundary
+
+The sample application applies a **permissions boundary** to its function's execution role. The permissions boundary limits the permissions that you can add to the function's role. Without the boundary, users with write access to the project repository could modify the project template to give the function permission to access resources and services outside of the scope of the sample application.
+
+In order for the function to use the queue that you added in the previous step, you must extend the permissions boundary. The Lambda console detects resources that aren't in the permissions boundary and provides an updated policy that you can use to update it.
+
+**To update the application's permissions boundary**
+
+1. Open the [**Applications**](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Edit permissions boundary**.
+1. Follow the instructions shown to update the boundary to allow access to the new queue.
+
+## Update the function configuration
+
+Now you can grant the function permission to access the queue and configure the dead-letter queue setting.
+
+In the function's properties in `template.yml`, add the **DeadLetterQueue** configuration. Under Policies, add **SQSSendMessagePolicy**. **SQSSendMessagePolicy** is a [policy template](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-policy-templates.html) that grants the function permission to send messages to a queue.
+
+```
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+  sqsPayloadLoggerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: src/handlers/sqs-payload-logger.sqsPayloadLoggerHandler
+      Runtime: nodejs14.x
+      Description: A Lambda function that logs the payload of messages sent to an associated SQS queue.
+      MemorySize: 128
+      Timeout: 25
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !GetAtt MyQueue.Arn
+      Policies:
+        - SQSSendMessagePolicy:
+            QueueName: !GetAtt MyQueue.QueueName
+        - AWSLambdaBasicExecutionRole
+      Events:
+        SimpleQueueEvent:
+          Type: SQS
+          Properties:
+            Queue: !GetAtt SimpleQueue.Arn
+```
+
+Commit and push the change. When the deployment completes, view the function in the console to see the updated configuration that specifies the dead-letter queue.
+
+## Build and test locally
+
+The AWS SAM command line interface (CLI) is an extension of the AWS CLI that adds functionality for building and testing Lambda applications. It uses Docker to run your functions in an Amazon Linux environment that matches Lambda. It can also emulate your application's build environment and API.
+
+If you prefer to use an integrated development environment (IDE) to build and test your application, you can use the AWS Toolkit.
+The AWS Toolkit is an open-source plugin for popular IDEs that uses the AWS SAM CLI to build and deploy serverless applications on AWS. The AWS Toolkit also adds step-through debugging for Lambda function code.
+
+To get started, see the following:
+
+* [PyCharm](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [IntelliJ](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [VS Code](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html)
+* [Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/welcome.html)
+
+To use the AWS SAM CLI with this sample, you need the following tools:
+
+* AWS CLI - [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) and [configure it with your AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
+* AWS SAM CLI - [Install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html).
+* Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community).
+
+Build your application with the `sam build` command.
+
+```bash
+my-application$ sam build -m package.json
+```
+
+The AWS SAM CLI installs dependencies that are defined in `package.json`, creates a deployment package, and saves its contents in the `.aws-sam/build` folder.
+
+Test a single function by invoking it directly with a test event. An event is a JSON document that represents the input that the function receives from the event source. Test events are included in the `events` folder in this project.
+
+Run functions locally and invoke them with the `sam local invoke` command.
+
+```bash
+my-application$ sam local invoke sqsPayloadLoggerFunction --event events/event-sqs.json
+```
+
+## Unit tests
+
+Requirements:
+
+* Node.js - [Install Node.js 14.x](https://nodejs.org/en/), including the npm package management tool.
+
+Tests are defined in the \_\_tests__ folder in this project. Use `npm` to install the [Jest test framework](https://jestjs.io/) and run unit tests.
+
+```bash
+my-application$ npm install
+my-application$ npm run test
+```
+
+## Resources
+
+For an introduction to the AWS SAM specification, the AWS SAM CLI, and serverless application concepts, see the [AWS SAM Developer Guide](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html).
+
+Next, you can use the AWS Serverless Application Repository to deploy ready-to-use apps that go beyond Hello World samples and learn how authors developed their applications. For more information, see the [AWS Serverless Application Repository main page](https://aws.amazon.com/serverless/serverlessrepo/) and the [AWS Serverless Application Repository Developer Guide](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/what-is-serverlessrepo.html).

--- a/nodejs14.x/queue-processing/sam/__tests__/unit/handlers/sqs-payload-logger.test.js
+++ b/nodejs14.x/queue-processing/sam/__tests__/unit/handlers/sqs-payload-logger.test.js
@@ -1,0 +1,40 @@
+// Import all functions from sqs-payload-logger.js
+const sqsPayloadLogger = require('../../../src/handlers/sqs-payload-logger.js');
+
+describe('Test for sqs-payload-logger', () => {
+    // This test invokes the sqs-payload-logger Lambda function and verifies that the received payload is logged
+    it('Verifies the payload is logged', async () => {
+        // Mock console.log statements so we can verify them. For more information, see
+        // https://jestjs.io/docs/en/mock-functions.html
+        console.log = jest.fn();
+
+        // Create a sample payload with SQS message format
+        const payload = {
+            Records: [
+                {
+                    messageId: '19dd0b57-b21e-4ac1-bd88-01bbb068cb78',
+                    receiptHandle: 'MessageReceiptHandle',
+                    body: 'Hello from SQS!',
+                    attributes: {
+                        ApproximateReceiveCount: '1',
+                        SentTimestamp: '1523232000000',
+                        SenderId: '012345678910',
+                        ApproximateFirstReceiveTimestamp: '1523232000001',
+                    },
+                    messageAttributes: {},
+                    md5OfBody: '7b270e59b47ff90a553787216d55d91d',
+                    eventSource: 'aws:sqs',
+                    eventSourceARN: 'arn:aws:sqs:us-west-2:012345678910:SimpleQueue',
+                    awsRegion: 'us-west-2',
+                },
+            ],
+        };
+
+        await sqsPayloadLogger.sqsPayloadLoggerHandler(payload, null);
+
+        // Verify that console.log has been called with the expected payload
+        payload.Records.forEach((record, i) => {
+            expect(console.log).toHaveBeenNthCalledWith(i + 1, JSON.stringify(record));
+        });
+    });
+});

--- a/nodejs14.x/queue-processing/sam/buildspec.yml
+++ b/nodejs14.x/queue-processing/sam/buildspec.yml
@@ -1,0 +1,22 @@
+version: 0.2
+phases:
+  install:
+    commands:
+      # Install all dependencies (including dependencies for running tests)
+      - npm install
+  pre_build:
+    commands:
+      # Discover and run unit tests in the '__tests__' directory
+      - npm run test
+      # Remove all unit tests to reduce the size of the package that will be ultimately uploaded to Lambda
+      - rm -rf ./__tests__
+      # Remove all dependencies not needed for the Lambda deployment package (the packages from devDependencies in package.json)
+      - npm prune --production
+  build:
+    commands:
+      # Use AWS SAM to package the application by using AWS CloudFormation
+      - aws cloudformation package --template template.yml --s3-bucket $S3_BUCKET --output-template template-export.yml
+artifacts:
+  type: zip
+  files:
+    - template-export.yml

--- a/nodejs14.x/queue-processing/sam/events/event-sqs.json
+++ b/nodejs14.x/queue-processing/sam/events/event-sqs.json
@@ -1,0 +1,20 @@
+{
+  "Records": [
+    {
+      "messageId": "19dd0b57-b21e-4ac1-bd88-01bbb068cb78",
+      "receiptHandle": "MessageReceiptHandle",
+      "body": "Hello from SQS!",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1523232000000",
+        "SenderId": "012345678910",
+        "ApproximateFirstReceiveTimestamp": "1523232000001"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "7b270e59b47ff90a553787216d55d91d",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:us-west-2:012345678910:SimpleQueue",
+      "awsRegion": "us-west-2"
+    }
+  ]
+}

--- a/nodejs14.x/queue-processing/sam/package.json
+++ b/nodejs14.x/queue-processing/sam/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "lambda-sqs",
+    "description": "Lambda-SQS starter project",
+    "version": "0.0.1",
+    "private": true,
+    "dependencies": {
+    },
+    "devDependencies": {
+        "jest": "^24.7.1"
+    },
+    "scripts": {
+        "test": "jest"
+    }
+}

--- a/nodejs14.x/queue-processing/sam/src/handlers/sqs-payload-logger.js
+++ b/nodejs14.x/queue-processing/sam/src/handlers/sqs-payload-logger.js
@@ -1,0 +1,10 @@
+/**
+ * A Lambda function that logs the payload received from SQS.
+ */
+exports.sqsPayloadLoggerHandler = async (event, context) => {
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    event.Records.forEach((record) => {
+        console.log(JSON.stringify(record));
+    });
+};

--- a/nodejs14.x/queue-processing/sam/template.yml
+++ b/nodejs14.x/queue-processing/sam/template.yml
@@ -1,0 +1,55 @@
+# This is the SAM template that represents the architecture of your serverless application
+# https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-template-basics.html
+
+# The AWSTemplateFormatVersion identifies the capabilities of the template
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/format-version-structure.html
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Lambda-SQS starter project
+
+# Transform section specifies one or more macros that AWS CloudFormation uses to process your template
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-section-structure.html
+Transform: AWS::Serverless-2016-10-31
+
+# Shared configuration for all resources, more in
+# https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
+Globals:
+  Function:
+    # The PermissionsBoundary allows users to safely develop with their function's permissions constrained
+    # to their current application. All the functions and roles in this application have to include it and
+    # it has to be manually updated when you add resources to your application.
+    # More information in https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html
+    PermissionsBoundary: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/${AppId}-${AWS::Region}-PermissionsBoundary'
+
+Parameters:
+  AppId:
+    Type: String
+
+# Resources declares the AWS resources that you want to include in the stack
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html
+Resources:
+  # Each Lambda function is defined by properties:
+  # https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+
+  # This is a Lambda function config associated with the source code: sqs-payload-logger.js
+  sqsPayloadLoggerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: src/handlers/sqs-payload-logger.sqsPayloadLoggerHandler
+      Runtime: nodejs14.x
+      Description: A Lambda function that logs the payload of messages sent to an associated SQS queue.
+      MemorySize: 128
+      Timeout: 25 # Chosen to be less than the default SQS Visibility Timeout of 30 seconds
+      Policies:
+        # Give Lambda basic execution Permission to the sqsPayloadLogger
+        - AWSLambdaBasicExecutionRole
+      Events:
+        SimpleQueueEvent:
+          Type: SQS
+          Properties:
+            Queue: !GetAtt SimpleQueue.Arn
+  # This is an SQS queue with all default configuration properties. To learn more about the available options, see
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html
+  SimpleQueue:
+    Type: AWS::SQS::Queue

--- a/nodejs14.x/scheduled-job/cdk/.gitignore
+++ b/nodejs14.x/scheduled-job/cdk/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/nodejs14.x/scheduled-job/cdk/LICENSE
+++ b/nodejs14.x/scheduled-job/cdk/LICENSE
@@ -1,0 +1,14 @@
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/nodejs14.x/scheduled-job/cdk/README.md
+++ b/nodejs14.x/scheduled-job/cdk/README.md
@@ -1,0 +1,179 @@
+# Lambda-Scheduled Event starter project
+
+This project contains source code and supporting files for the serverless application that you created in the AWS Lambda console. You can update your application at any time by committing and pushing changes to your AWS CodeCommit or GitHub repository.
+
+This project includes the following files and folders:
+
+- src - Code for the application's Lambda function.
+- events - Invocation events that you can use to invoke the function.
+- \_\_tests__ - Unit tests for the application code.
+- cdk - The CDK model that defines the application's AWS resources.
+- buildspec.yml -  A build specification file that tells AWS CodeBuild how to create a deployment package for the function.
+
+Your Lambda application includes two AWS CloudFormation stacks. The first stack creates the pipeline that builds and deploys your application.
+
+The pipeline creates a second stack that contains your application's resources, including Lambda functions and a CloudWatch Events scheduled event. These resources are defined in the `cdk/lib/cdk-stack.ts` file in this project. You can update the CDK model to add AWS resources through the same deployment process that updates your application code. You can view those resources in the **Resources** section of the application overview in the Lambda console.
+
+For a full list of possible operations, see the [AWS Lambda Applications documentation](https://docs.aws.amazon.com/lambda/latest/dg/deploying-lambda-apps.html).
+
+## Try the application out
+
+1. Go to the Lambda console.
+2. Select **Applications** and select the one you created.
+3. The function runs every hour at the top of the hour (for example, at 5:00 and then at 6:00), so the function will be invoked after the next hour mark is reached.
+4. You can click the function name in the **Resources** table to go to the function's page to directly try it there using the **Test** button, if you don't want to wait for the next hour.
+5. On that function's page, select the **Monitoring** tab, then click **View Logs in CloudWatch**, which will take you to the CloudWatch Logs console.
+6. Click on the latest log stream entry, and you will find your log statement.
+
+## Add a resource to your application
+
+The application template uses the AWS Cloud Development Kit (AWS CDK) to define application resources. AWS CDK is an open source software development framework that you can use to model and provision your cloud application resources using familiar programming languages. It provides a library of high-level constructs that simplify resource creation, and an interface for working with CloudFormation resource types directly when needed. When you build an AWS CDK project, the output is a CloudFormation template that defines your application.
+
+The application's resources are defined in `cdk/lib/cdk-stack.ts`. To add a destination to your application, add `@aws-cdk/aws-sqs` and `@aws-cdk/aws-lambda-destinations` to `cdk/package.json`.
+
+```json
+{
+    ...
+    "dependencies": {
+        ...
+        "@aws-cdk/aws-lambda": "^1.31.0",
+        "@aws-cdk/aws-lambda-destinations": "^1.31.0",
+        "@aws-cdk/aws-sqs": "^1.31.0",
+        ...
+    }
+}
+```
+
+Then import the `@aws-cdk/aws-sqs` module and define a `Queue` resource in the class constructor.
+
+**cdk/lib/cdk-stack.ts**
+```typescript
+import * as s3 from '@aws-cdk/aws-s3';
+import { Queue } from '@aws-cdk/aws-sqs';
+...
+
+export class CdkStack extends Stack {
+    constructor(scope: App, id: string, props: StackProps) {
+        super(scope, id, props);
+
+        new CfnParameter(this, 'AppId');
+        // Lambda destination
+        const destination = new Queue(this, 'DestinationQueue');
+        ...
+```
+
+The destination is a location for Lambda to send events that could not be processed. It's only used if you invoke your function asynchronously, but it's useful here to show how you can modify your application's resources and function configuration.
+
+Commit the change and push.
+
+```bash
+my-application$ git commit -am "Add destination queue."
+my-application$ git push
+```
+
+**To see how the pipeline processes and deploys the change**
+
+1. Open the [Applications](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Deployments**.
+
+When the deployment is complete, view the application resources on the **Overview** tab to see the new resource.
+
+## Update the permissions boundary
+
+The sample application applies a **permissions boundary** to its function's execution role. The permissions boundary limits the permissions that you can add to the function's role. Without the boundary, users with write access to the project repository could modify the project template to give the function permission to access resources and services outside of the scope of the sample application.
+
+In order for the function to use the queue that you added in the previous step, you must extend the permissions boundary. The Lambda console detects resources that aren't in the permissions boundary and provides an updated policy that you can use to update it.
+
+**To update the application's permissions boundary**
+
+1. Open the [Applications](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Edit permissions boundary**.
+1. Follow the instructions shown to update the boundary to allow access to the new queue.
+
+## Update the function configuration
+
+Now you can grant the function permission to access the queue and configure the destinations setting.
+
+In the function's properties in `cdk/lib/cdk-stack.ts`, import the `@aws-cdk/aws-lambda-destinations` module and add an `SqsDestination` resource to the **onFailure** destinations configuration.
+
+```typescript
+import { SqsDestination } from '@aws-cdk/aws-lambda-destinations';
+import * as s3 from '@aws-cdk/aws-s3';
+import { Queue } from '@aws-cdk/aws-sqs';
+...
+
+// This is a Lambda function config associated with the source code: scheduled-event-logger.js
+const scheduledEventLoggerFunction = new lambda.Function(this, 'scheduledEventLogger', {
+    description: 'A Lambda function that logs the payload of scheduled events.',
+    handler: 'src/handlers/scheduled-event-logger.scheduledEventLoggerHandler',
+    runtime: lambda.Runtime.NODEJS_14_X,
+    code: lambda.Code.fromBucket(
+        s3.Bucket.fromBucketName(this, 'ArtifactBucket', artifactBucket),
+        artifactKey,
+    ),
+    onFailure: new SqsDestination(destination),
+});
+```
+
+Commit and push the change. When the deployment is complete, view the function in the console to see the updated configuration that specifies the destination.
+
+## Build and test locally
+
+The AWS SAM command line interface (CLI) is an extension of the AWS CLI that adds functionality for building and testing Lambda applications. It uses Docker to run your functions in an Amazon Linux environment that matches Lambda. It can also emulate your application's build environment and API.
+
+If you prefer to use an integrated development environment (IDE) to build and test your application, you can use the AWS Toolkit.
+The AWS Toolkit is an open-source plugin for popular IDEs that uses the AWS SAM CLI to build and deploy serverless applications on AWS. The AWS Toolkit also adds step-through debugging for Lambda function code.
+
+To get started, see the following:
+
+* [PyCharm](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [IntelliJ](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [VS Code](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html)
+* [Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/welcome.html)
+
+To use the AWS SAM CLI with this sample, you need the following tools:
+
+* AWS CLI - [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) and [configure it with your AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
+* AWS SAM CLI - [Install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html).
+* Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community).
+
+Compile your AWS CDK app and create a AWS CloudFormation template
+
+```bash
+my-application$ cd cdk
+cdk$ export S3_BUCKET=mockBucket
+cdk$ cdk synth --no-staging > ../template.yaml
+```
+
+Find the logical ID for your Lambda function in `template.yaml`. It will look like *scheduledEventLogger12345678*, where *12345678* represents an 8-character unique ID that the AWS CDK generates for all resources. The line right after it should look like `Type: AWS::Lambda::Function`.
+
+Test a single function by invoking it directly with a test event. An event is a JSON document that represents the input that the function receives from the event source. Test events are included in the `events` folder in this project.
+
+Although functions in `template.yaml` are specified to have deployment package in S3, AWS SAM CLI assumes the source code is in the same local directory as `template.yaml`.
+
+Run functions locally and invoke them with the `sam local invoke` command.
+
+```bash
+my-application$ sam local invoke scheduledEventLogger12345678 --event events/event-cloudwatch-event.json
+```
+
+## Unit tests
+
+Requirements:
+
+* Node.js - [Install Node.js 14.x](https://nodejs.org/en/), including the npm package management tool.
+
+Tests are defined in the \_\_tests__ folder in this project. Use `npm` to install the [Jest test framework](https://jestjs.io/) and run unit tests.
+
+```bash
+my-application$ npm install
+my-application$ npm run test
+```
+
+## Resources
+
+For an introduction to the AWS CDK specification, see the [AWS CDK Developer Guide](https://docs.aws.amazon.com/cdk/latest/guide/home.html).
+
+Next, you can use the AWS Serverless Application Repository to deploy ready-to-use apps that go beyond Hello World samples and learn how authors developed their applications. For more information, see the [AWS Serverless Application Repository main page](https://aws.amazon.com/serverless/serverlessrepo/) and the [AWS Serverless Application Repository Developer Guide](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/what-is-serverlessrepo.html).

--- a/nodejs14.x/scheduled-job/cdk/__tests__/unit/handlers/scheduled-event-logger.test.js
+++ b/nodejs14.x/scheduled-job/cdk/__tests__/unit/handlers/scheduled-event-logger.test.js
@@ -1,0 +1,30 @@
+// Import all functions from scheduled-event-logger.js
+const scheduledEventLogger = require('../../../src/handlers/scheduled-event-logger.js');
+
+describe('Test for scheduled-event-logger', () => {
+    // This test invokes the scheduled-event-logger Lambda function and verifies that the received payload is logged
+    it('Verifies the payload is logged', async () => {
+        // Mock console.log statements so we can verify them. For more information, see
+        // https://jestjs.io/docs/en/mock-functions.html
+        console.log = jest.fn();
+
+        // Create a sample payload with CloudWatch scheduled event message format
+        const payload = {
+            id: 'cdc73f9d-aea9-11e3-9d5a-835b769c0d9c',
+            'detail-type': 'Scheduled Event',
+            source: 'aws.events',
+            account: '',
+            time: '1970-01-01T00:00:00Z',
+            region: 'us-west-2',
+            resources: [
+                'arn:aws:events:us-west-2:123456789012:rule/ExampleRule',
+            ],
+            detail: {},
+        };
+
+        await scheduledEventLogger.scheduledEventLoggerHandler(payload, null);
+
+        // Verify that console.log has been called with the expected payload
+        expect(console.log).toHaveBeenCalledWith(JSON.stringify(payload));
+    });
+});

--- a/nodejs14.x/scheduled-job/cdk/buildspec.yml
+++ b/nodejs14.x/scheduled-job/cdk/buildspec.yml
@@ -1,0 +1,32 @@
+version: 0.2
+phases:
+  install:
+    commands:
+      # Install all dependencies (including dependencies for running tests)
+      - npm install
+      # Install CDK dependencies
+      - cd cdk
+      - npm install -g aws-cdk
+      - npm install
+      - cd ..
+  pre_build:
+    commands:
+      # Discover and run unit tests in the '__tests__' directory
+      - npm run test
+      # Remove all dependencies not needed for the Lambda deployment package (the packages from devDependencies in package.json)
+      - npm prune --production
+      # Copy artifacts to a separate folder
+      - mkdir function-code
+      - cp -r src node_modules function-code
+  build:
+    commands:
+      # Archive Lambda function code and upload it to S3
+      - cd function-code
+      - zip -r function-code.zip .
+      - aws s3 cp function-code.zip s3://$S3_BUCKET/$CODEBUILD_BUILD_ID/
+      # Use AWS CDK to synthesize the application
+      - cd ../cdk
+      - cdk synth > ../template-export.yml
+artifacts:
+  files:
+    - template-export.yml

--- a/nodejs14.x/scheduled-job/cdk/cdk/README.md
+++ b/nodejs14.x/scheduled-job/cdk/cdk/README.md
@@ -1,0 +1,8 @@
+# Useful commands
+
+ * `npm run build`   compile typescript to js
+ * `npm run watch`   watch for changes and compile
+ * `npm run test`    perform the jest unit tests
+ * `cdk deploy`      deploy this stack to your default AWS account/region
+ * `cdk diff`        compare deployed stack with current state
+ * `cdk synth`       emits the synthesized CloudFormation template

--- a/nodejs14.x/scheduled-job/cdk/cdk/bin/cdk.ts
+++ b/nodejs14.x/scheduled-job/cdk/cdk/bin/cdk.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import { App, Aws } from '@aws-cdk/core';
+
+import { CdkStack } from '../lib/cdk-stack';
+import { PermissionsBoundaryAspect } from '../lib/permissions-boundary-aspect';
+
+
+const stack = new CdkStack(new App(), 'CdkStack', { description: 'Lambda-Scheduled Event starter project' });
+const { ACCOUNT_ID, PARTITION, REGION, STACK_NAME } = Aws;
+const permissionBoundaryArn = `arn:${PARTITION}:iam::${ACCOUNT_ID}:policy/${STACK_NAME}-${REGION}-PermissionsBoundary`;
+
+// Apply permissions boundary to the stack
+stack.node.applyAspect(new PermissionsBoundaryAspect(permissionBoundaryArn));

--- a/nodejs14.x/scheduled-job/cdk/cdk/cdk.json
+++ b/nodejs14.x/scheduled-job/cdk/cdk/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "npx ts-node bin/cdk.ts"
+}

--- a/nodejs14.x/scheduled-job/cdk/cdk/jest.config.js
+++ b/nodejs14.x/scheduled-job/cdk/cdk/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+    'roots': [
+        '<rootDir>/test'
+    ],
+    testMatch: ['**/*.test.ts'],
+    'transform': {
+        '^.+\\.tsx?$': 'ts-jest'
+    },
+};

--- a/nodejs14.x/scheduled-job/cdk/cdk/lib/cdk-stack.ts
+++ b/nodejs14.x/scheduled-job/cdk/cdk/lib/cdk-stack.ts
@@ -1,0 +1,35 @@
+import * as events from '@aws-cdk/aws-events';
+import { LambdaFunction } from '@aws-cdk/aws-events-targets';
+import * as lambda from '@aws-cdk/aws-lambda';
+import * as s3 from '@aws-cdk/aws-s3';
+import { App, CfnParameter, Stack, StackProps } from '@aws-cdk/core';
+
+
+export class CdkStack extends Stack {
+    constructor(scope: App, id: string, props: StackProps) {
+        super(scope, id, props);
+
+        new CfnParameter(this, 'AppId');
+
+        // The code will be uploaded to this location during the pipeline's build step
+        const artifactBucket = process.env.S3_BUCKET!;
+        const artifactKey = `${process.env.CODEBUILD_BUILD_ID}/function-code.zip`;
+
+        // This is a Lambda function config associated with the source code: scheduled-event-logger.js
+        const scheduledEventLoggerFunction = new lambda.Function(this, 'scheduledEventLogger', {
+            description: 'A Lambda function that logs the payload of scheduled events.',
+            handler: 'src/handlers/scheduled-event-logger.scheduledEventLoggerHandler',
+            runtime: lambda.Runtime.NODEJS_14_X,
+            code: lambda.Code.fromBucket(
+                s3.Bucket.fromBucketName(this, 'ArtifactBucket', artifactBucket),
+                artifactKey,
+            ),
+        });
+
+        new events.Rule(this, 'SimpleCWEEvent', {
+            // Runs every hour at the top of the hour (for example, at 5:00 and then at 6:00)
+            schedule: events.Schedule.expression('cron(0 * * * ? *)'),
+            targets: [new LambdaFunction(scheduledEventLoggerFunction)],
+        });
+    }
+}

--- a/nodejs14.x/scheduled-job/cdk/cdk/lib/permissions-boundary-aspect.ts
+++ b/nodejs14.x/scheduled-job/cdk/cdk/lib/permissions-boundary-aspect.ts
@@ -1,0 +1,18 @@
+import * as iam from '@aws-cdk/aws-iam';
+import { IAspect, IConstruct } from '@aws-cdk/core';
+
+
+export class PermissionsBoundaryAspect implements IAspect {
+    private readonly arn: string;
+
+    constructor(permissionBoundaryArn: string) {
+        this.arn = permissionBoundaryArn;
+    }
+
+    public visit(node: IConstruct): void {
+        if (node instanceof iam.Role) {
+            const roleResource = node.node.findChild('Resource') as iam.CfnRole;
+            roleResource.addPropertyOverride('PermissionsBoundary', this.arn);
+        }
+    }
+}

--- a/nodejs14.x/scheduled-job/cdk/cdk/package.json
+++ b/nodejs14.x/scheduled-job/cdk/cdk/package.json
@@ -1,0 +1,30 @@
+{
+    "name": "lambda-scheduled-cdk",
+    "version": "0.0.1",
+    "bin": {
+        "cdk": "bin/cdk.js"
+    },
+    "scripts": {
+        "build": "tsc",
+        "watch": "tsc -w",
+        "test": "jest",
+        "cdk": "cdk"
+    },
+    "devDependencies": {
+        "@aws-cdk/assert": "^1.31.0",
+        "@types/jest": "^25.2.1",
+        "@types/node": "^10.17.5",
+        "aws-cdk": "^1.31.0",
+        "jest": "^25.4.0",
+        "ts-jest": "^25.4.0",
+        "ts-node": "^8.9.0",
+        "typescript": "^3.8.3"
+    },
+    "dependencies": {
+        "@aws-cdk/aws-events": "^1.31.0",
+        "@aws-cdk/aws-events-targets": "^1.31.0",
+        "@aws-cdk/aws-lambda": "^1.31.0",
+        "@aws-cdk/aws-s3": "^1.31.0",
+        "@aws-cdk/core": "^1.31.0"
+    }
+}

--- a/nodejs14.x/scheduled-job/cdk/cdk/package.json
+++ b/nodejs14.x/scheduled-job/cdk/cdk/package.json
@@ -13,7 +13,7 @@
     "devDependencies": {
         "@aws-cdk/assert": "^1.31.0",
         "@types/jest": "^25.2.1",
-        "@types/node": "^10.17.5",
+        "@types/node": "^14.17.5",
         "aws-cdk": "^1.31.0",
         "jest": "^25.4.0",
         "ts-jest": "^25.4.0",

--- a/nodejs14.x/scheduled-job/cdk/cdk/tsconfig.json
+++ b/nodejs14.x/scheduled-job/cdk/cdk/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "target": "ES2018",
+        "module": "commonjs",
+        "lib": [
+            "es2016",
+            "es2017.object",
+            "es2017.string"
+        ],
+        "declaration": true,
+        "strict": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "noImplicitThis": true,
+        "alwaysStrict": true,
+        "noUnusedLocals": false,
+        "noUnusedParameters": false,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": false,
+        "inlineSourceMap": true,
+        "inlineSources": true,
+        "experimentalDecorators": true,
+        "strictPropertyInitialization": false,
+        "typeRoots": [
+            "./node_modules/@types"
+        ]
+    },
+    "exclude": [
+        "cdk.out"
+    ]
+}

--- a/nodejs14.x/scheduled-job/cdk/events/event-cloudwatch-event.json
+++ b/nodejs14.x/scheduled-job/cdk/events/event-cloudwatch-event.json
@@ -1,0 +1,12 @@
+{
+  "id": "cdc73f9d-aea9-11e3-9d5a-835b769c0d9c",
+  "detail-type": "Scheduled Event",
+  "source": "aws.events",
+  "account": "123456789012",
+  "time": "1970-01-01T00:00:00Z",
+  "region": "us-west-2",
+  "resources": [
+    "arn:aws:events:us-west-2:123456789012:rule/ExampleRule"
+  ],
+  "detail": {}
+}

--- a/nodejs14.x/scheduled-job/cdk/package.json
+++ b/nodejs14.x/scheduled-job/cdk/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "lambda-scheduled",
+    "description": "Lambda-Scheduled Event starter project",
+    "version": "0.0.1",
+    "private": true,
+    "dependencies": {
+    },
+    "devDependencies": {
+        "jest": "^25.4.0"
+    },
+    "scripts": {
+        "test": "jest"
+    }
+}

--- a/nodejs14.x/scheduled-job/cdk/src/handlers/scheduled-event-logger.js
+++ b/nodejs14.x/scheduled-job/cdk/src/handlers/scheduled-event-logger.js
@@ -1,0 +1,8 @@
+/**
+ * A Lambda function that logs the payload received from a CloudWatch scheduled event.
+ */
+exports.scheduledEventLoggerHandler = async (event, context) => {
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    console.log(JSON.stringify(event));
+};

--- a/nodejs14.x/scheduled-job/sam/.gitignore
+++ b/nodejs14.x/scheduled-job/sam/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/nodejs14.x/scheduled-job/sam/README.md
+++ b/nodejs14.x/scheduled-job/sam/README.md
@@ -1,0 +1,158 @@
+# Lambda-Scheduled Event starter project
+
+This project contains source code and supporting files for the serverless application that you created in the AWS Lambda console. You can update your application at any time by committing and pushing changes to your AWS CodeCommit or GitHub repository.
+
+This project includes the following files and folders:
+
+- src - Code for the application's Lambda function.
+- events - Invocation events that you can use to invoke the function.
+- \_\_tests__ - Unit tests for the application code.
+- template.yml - A SAM template that defines the application's AWS resources.
+- buildspec.yml -  A build specification file that tells AWS CodeBuild how to create a deployment package for the function.
+
+Your Lambda application includes two AWS CloudFormation stacks. The first stack creates the pipeline that builds and deploys your application.
+
+The pipeline creates a second stack that contains your application's resources, including Lambda functions, and CloudWatch Events scheduled event. These resources are defined in the `template.yml` file in this project. You can update the template to add AWS resources through the same deployment process that updates your application code. You can view those resources in the **Resources** section of the application overview in the Lambda console.
+
+For a full list of possible operations, see the [AWS Lambda Applications documentation](https://docs.aws.amazon.com/lambda/latest/dg/deploying-lambda-apps.html).
+
+## Try the application out
+
+1. Go to the Lambda console.
+2. Select **Applications** and select the one you created.
+3. The function runs every hour at the top of the hour (for example, at 5:00 and then at 6:00), so the function will be invoked after the next hour mark is reached.
+4. You can click the function name in the **Resources** table to go to the function's page to directly try it there using the **Test** button, if you don't want to wait for the next hour.
+5. On that function's page, select the **Monitoring** tab, then click **View Logs in CloudWatch**, which will take you to the CloudWatch Logs console.
+6. Click on the latest log stream entry, and you will find your log statement.
+
+## Add a resource to your application
+
+The application template uses the AWS Serverless Application Model (AWS SAM) to define application resources. AWS SAM is an extension of AWS CloudFormation with a simpler syntax for configuring common serverless application resources, such as functions, triggers, and APIs. For resources that aren't included in the [AWS SAM specification](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md), you can use the standard [AWS CloudFormation resource types](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html).
+
+Update `template.yml` to add a dead-letter queue to your application. In the **Resources** section, add a resource named **MyQueue** with the type **AWS::SQS::Queue**.
+
+```
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+```
+
+The dead-letter queue is a location for Lambda to send events that could not be processed. It's only used if you invoke your function asynchronously, but it's useful here to show how you can modify your application's resources and function configuration.
+
+Commit the change and push.
+
+```bash
+my-application$ git commit -am "Add dead-letter queue."
+my-application$ git push
+```
+
+**To see how the pipeline processes and deploys the change**
+
+1. Open the [**Applications**](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Deployments**.
+
+When the deployment completes, view the application resources on the **Overview** tab to see the new resource.
+
+## Update the permissions boundary
+
+The sample application applies a **permissions boundary** to its function's execution role. The permissions boundary limits the permissions that you can add to the function's role. Without the boundary, users with write access to the project repository could modify the project template to give the function permission to access resources and services outside of the scope of the sample application.
+
+In order for the function to use the queue that you added in the previous step, you must extend the permissions boundary. The Lambda console detects resources that aren't in the permissions boundary and provides an updated policy that you can use to update it.
+
+**To update the application's permissions boundary**
+
+1. Open the [**Applications**](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Edit permissions boundary**.
+1. Follow the instructions shown to update the boundary to allow access to the new queue.
+
+## Update the function configuration
+
+Now you can grant the function permission to access the queue and configure the dead-letter queue setting.
+
+In the function's properties in `template.yml`, add the **DeadLetterQueue** configuration. Under Policies, add **SQSSendMessagePolicy**. **SQSSendMessagePolicy** is a [policy template](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-policy-templates.html) that grants the function permission to send messages to a queue.
+
+```
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+  scheduledEventLoggerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: src/handlers/scheduled-event-logger.scheduledEventLoggerHandler
+      Runtime: nodejs14.x
+      Description: A Lambda function that logs the payload of scheduled events.
+      MemorySize: 128
+      Timeout: 60
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !GetAtt MyQueue.Arn
+      Policies:
+        - SQSSendMessagePolicy:
+            QueueName: !GetAtt MyQueue.QueueName
+        - AWSLambdaBasicExecutionRole
+      Events:
+        SimpleCWEEvent:
+          Type: Schedule
+          Properties:
+            Schedule: cron(0 * * * ? *)
+```
+
+Commit and push the change. When the deployment completes, view the function in the console to see the updated configuration that specifies the dead-letter queue.
+
+## Build and test locally
+
+The AWS SAM command line interface (CLI) is an extension of the AWS CLI that adds functionality for building and testing Lambda applications. It uses Docker to run your functions in an Amazon Linux environment that matches Lambda. It can also emulate your application's build environment and API.
+
+If you prefer to use an integrated development environment (IDE) to build and test your application, you can use the AWS Toolkit.
+The AWS Toolkit is an open-source plugin for popular IDEs that uses the AWS SAM CLI to build and deploy serverless applications on AWS. The AWS Toolkit also adds step-through debugging for Lambda function code.
+
+To get started, see the following:
+
+* [PyCharm](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [IntelliJ](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [VS Code](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html)
+* [Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/welcome.html)
+
+To use the AWS SAM CLI with this sample, you need the following tools:
+
+* AWS CLI - [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) and [configure it with your AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
+* AWS SAM CLI - [Install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html).
+* Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community).
+
+Build your application with the `sam build` command.
+
+```bash
+my-application$ sam build -m package.json
+```
+
+The AWS SAM CLI installs dependencies that are defined in `package.json`, creates a deployment package, and saves its contents in the `.aws-sam/build` folder.
+
+Test a single function by invoking it directly with a test event. An event is a JSON document that represents the input that the function receives from the event source. Test events are included in the `events` folder in this project.
+
+Run functions locally and invoke them with the `sam local invoke` command.
+
+```bash
+sam local invoke scheduledEventLoggerFunction --event events/event-cloudwatch-event.json
+```
+
+## Unit tests
+
+Requirements:
+
+* Node.js - [Install Node.js 14.x](https://nodejs.org/en/), including the npm package management tool.
+
+Tests are defined in the \_\_tests__ folder in this project. Use `npm` to install the [Jest test framework](https://jestjs.io/) and run unit tests.
+
+```bash
+my-application$ npm install
+my-application$ npm run test
+```
+
+## Resources
+
+For an introduction to the AWS SAM specification, the AWS SAM CLI, and serverless application concepts, see the [AWS SAM Developer Guide](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html).
+
+Next, you can use the AWS Serverless Application Repository to deploy ready-to-use apps that go beyond Hello World samples and learn how authors developed their applications. For more information, see the [AWS Serverless Application Repository main page](https://aws.amazon.com/serverless/serverlessrepo/) and the [AWS Serverless Application Repository Developer Guide](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/what-is-serverlessrepo.html).

--- a/nodejs14.x/scheduled-job/sam/__tests__/unit/handlers/scheduled-event-logger.test.js
+++ b/nodejs14.x/scheduled-job/sam/__tests__/unit/handlers/scheduled-event-logger.test.js
@@ -1,0 +1,30 @@
+// Import all functions from scheduled-event-logger.js
+const scheduledEventLogger = require('../../../src/handlers/scheduled-event-logger.js');
+
+describe('Test for scheduled-event-logger', () => {
+    // This test invokes the scheduled-event-logger Lambda function and verifies that the received payload is logged
+    it('Verifies the payload is logged', async () => {
+        // Mock console.log statements so we can verify them. For more information, see
+        // https://jestjs.io/docs/en/mock-functions.html
+        console.log = jest.fn();
+
+        // Create a sample payload with CloudWatch scheduled event message format
+        const payload = {
+            id: 'cdc73f9d-aea9-11e3-9d5a-835b769c0d9c',
+            'detail-type': 'Scheduled Event',
+            source: 'aws.events',
+            account: '',
+            time: '1970-01-01T00:00:00Z',
+            region: 'us-west-2',
+            resources: [
+                'arn:aws:events:us-west-2:123456789012:rule/ExampleRule',
+            ],
+            detail: {},
+        };
+
+        await scheduledEventLogger.scheduledEventLoggerHandler(payload, null);
+
+        // Verify that console.log has been called with the expected payload
+        expect(console.log).toHaveBeenCalledWith(JSON.stringify(payload));
+    });
+});

--- a/nodejs14.x/scheduled-job/sam/buildspec.yml
+++ b/nodejs14.x/scheduled-job/sam/buildspec.yml
@@ -1,0 +1,22 @@
+version: 0.2
+phases:
+  install:
+    commands:
+      # Install all dependencies (including dependencies for running tests)
+      - npm install
+  pre_build:
+    commands:
+      # Discover and run unit tests in the '__tests__' directory
+      - npm run test
+      # Remove all unit tests to reduce the size of the package that will be ultimately uploaded to Lambda
+      - rm -rf ./__tests__
+      # Remove all dependencies not needed for the Lambda deployment package (the packages from devDependencies in package.json)
+      - npm prune --production
+  build:
+    commands:
+      # Use AWS SAM to package the application by using AWS CloudFormation
+      - aws cloudformation package --template template.yml --s3-bucket $S3_BUCKET --output-template template-export.yml
+artifacts:
+  type: zip
+  files:
+    - template-export.yml

--- a/nodejs14.x/scheduled-job/sam/events/event-cloudwatch-event.json
+++ b/nodejs14.x/scheduled-job/sam/events/event-cloudwatch-event.json
@@ -1,0 +1,12 @@
+{
+  "id": "cdc73f9d-aea9-11e3-9d5a-835b769c0d9c",
+  "detail-type": "Scheduled Event",
+  "source": "aws.events",
+  "account": "123456789012",
+  "time": "1970-01-01T00:00:00Z",
+  "region": "us-west-2",
+  "resources": [
+    "arn:aws:events:us-west-2:123456789012:rule/ExampleRule"
+  ],
+  "detail": {}
+}

--- a/nodejs14.x/scheduled-job/sam/package.json
+++ b/nodejs14.x/scheduled-job/sam/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "lambda-scheduled",
+    "description": "Lambda-Scheduled Event starter project",
+    "version": "0.0.1",
+    "private": true,
+    "dependencies": {
+    },
+    "devDependencies": {
+        "jest": "^24.7.1"
+    },
+    "scripts": {
+        "test": "jest"
+    }
+}

--- a/nodejs14.x/scheduled-job/sam/src/handlers/scheduled-event-logger.js
+++ b/nodejs14.x/scheduled-job/sam/src/handlers/scheduled-event-logger.js
@@ -1,0 +1,8 @@
+/**
+ * A Lambda function that logs the payload received from a CloudWatch scheduled event.
+ */
+exports.scheduledEventLoggerHandler = async (event, context) => {
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    console.log(JSON.stringify(event));
+};

--- a/nodejs14.x/scheduled-job/sam/template.yml
+++ b/nodejs14.x/scheduled-job/sam/template.yml
@@ -1,0 +1,51 @@
+# This is the SAM template that represents the architecture of your serverless application
+# https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-template-basics.html
+
+# The AWSTemplateFormatVersion identifies the capabilities of the template
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/format-version-structure.html
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Lambda-Scheduled Event starter project
+
+# Transform section specifies one or more macros that AWS CloudFormation uses to process your template
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-section-structure.html
+Transform: AWS::Serverless-2016-10-31
+
+# Shared configuration for all resources, more in
+# https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
+Globals:
+  Function:
+    # The PermissionsBoundary allows users to safely develop with their function's permissions constrained
+    # to their current application. All the functions and roles in this application have to include it and
+    # it has to be manually updated when you add resources to your application.
+    # More information in https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html
+    PermissionsBoundary: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/${AppId}-${AWS::Region}-PermissionsBoundary'
+
+Parameters:
+  AppId:
+    Type: String
+
+# Resources declares the AWS resources that you want to include in the stack
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html
+Resources:
+  # Each Lambda function is defined by properties:
+  # https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+
+  # This is a Lambda function config associated with the source code: scheduled-event-logger.js
+  scheduledEventLoggerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: src/handlers/scheduled-event-logger.scheduledEventLoggerHandler
+      Runtime: nodejs14.x
+      Description: A Lambda function that logs the payload of scheduled events.
+      MemorySize: 128
+      Timeout: 60
+      Policies:
+        # Give Lambda basic execution Permission to the scheduledEventLogger
+        - AWSLambdaBasicExecutionRole
+      Events:
+        SimpleCWEEvent:
+          Type: Schedule
+          Properties:
+            Schedule: cron(0 * * * ? *)

--- a/nodejs14.x/serverless-api-backend/cdk/.gitignore
+++ b/nodejs14.x/serverless-api-backend/cdk/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/nodejs14.x/serverless-api-backend/cdk/LICENSE
+++ b/nodejs14.x/serverless-api-backend/cdk/LICENSE
@@ -1,0 +1,14 @@
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/nodejs14.x/serverless-api-backend/cdk/README.md
+++ b/nodejs14.x/serverless-api-backend/cdk/README.md
@@ -1,0 +1,207 @@
+# Website & Mobile starter project
+
+This project contains source code and supporting files for the serverless application that you created in the AWS Lambda console. You can update your application at any time by committing and pushing changes to your AWS CodeCommit or GitHub repository.
+
+This project includes the following files and folders:
+
+- src - Code for the application's Lambda function.
+- events - Invocation events that you can use to invoke the function.
+- \_\_tests__ - Unit tests for the application code.
+- cdk - The CDK model that defines the application's AWS resources.
+- buildspec.yml -  A build specification file that tells AWS CodeBuild how to create a deployment package for the function.
+
+Your Lambda application includes two AWS CloudFormation stacks. The first stack creates the pipeline that builds and deploys your application.
+
+The pipeline creates a second stack that contains your application's resources, including Lambda functions, an API Gateway API and an Amazon DynamoDB table. These resources are defined in the `cdk/lib/cdk-stack.ts` file in this project. You can update the CDK model to add AWS resources through the same deployment process that updates your application code. You can view those resources in the **Resources** section of the application overview in the Lambda console.
+
+For a full list of possible operations, see the [AWS Lambda Applications documentation](https://docs.aws.amazon.com/lambda/latest/dg/deploying-lambda-apps.html).
+
+## Try the application out
+
+The sample application creates a RESTful API that takes HTTP requests and invokes Lambda functions. The API has POST and GET methods on the root path to create and list items. It has a GET method that takes an ID path parameter to retrieve items. Each method maps to one of the application's three Lambda functions.
+
+**To use the sample API**
+
+1. Choose your application from the [**Applications page**](https://console.aws.amazon.com/lambda/home#/applications) in the Lambda console. (Make sure you're in the right region)
+1. Copy the URL that's listed under **API endpoint**.
+1. At the command line, use cURL to send POST requests to the application endpoint.
+
+        $ ENDPOINT=<paste-your-endpoint-here>
+        $ curl -d '{"id":"1234ABCD", "name":"My item"}' -H "Content-Type: application/json" -X POST $ENDPOINT
+        {"id":"1234ABCD","name":"My item"}
+        $ curl -d '{"id":"2234ABCD", "name":"My other item"}' -H "Content-Type: application/json" -X POST $ENDPOINT
+        {"id":"2234ABCD","name":"My other item"}
+
+1. Send a GET request to the endpoint to get a list of items.
+
+        $ curl $ENDPOINT
+        [{"id":"1234ABCD","name":"My item"},{"id":"2234ABCD","name":"My other item"}]
+
+1. Send a GET request with the item ID to get a single item.
+
+        $ curl $ENDPOINT/1234ABCD
+        {"id":"1234ABCD","name":"My item"}
+
+To view the application's API, functions, and table, use the links in the **Resources** section of the application overview in the Lambda console.
+
+## Add a resource to your application
+
+The application template uses the AWS Cloud Development Kit (AWS CDK) to define application resources. AWS CDK is an open source software development framework that you can use to model and provision your cloud application resources using familiar programming languages. It provides a library of high-level constructs that simplify resource creation, and an interface for working with CloudFormation resource types directly when needed. When you build an AWS CDK project, the output is a CloudFormation template that defines your application.
+
+The application's resources are defined in `cdk/lib/cdk-stack.ts`. To add a destination to your application, add `@aws-cdk/aws-sqs` and `@aws-cdk/aws-lambda-destinations` to `cdk/package.json`.
+
+```json
+{
+    ...
+    "dependencies": {
+        ...
+        "@aws-cdk/aws-lambda": "^1.31.0",
+        "@aws-cdk/aws-lambda-destinations": "^1.31.0",
+        "@aws-cdk/aws-sqs": "^1.31.0",
+        ...
+    }
+}
+```
+
+Then import the `@aws-cdk/aws-sqs` module and define a `Queue` resource in the class constructor.
+
+**cdk/lib/cdk-stack.ts**
+```typescript
+import * as s3 from '@aws-cdk/aws-s3';
+import { Queue } from '@aws-cdk/aws-sqs';
+...
+
+export class CdkStack extends Stack {
+    constructor(scope: App, id: string, props: StackProps) {
+        super(scope, id, props);
+
+        new CfnParameter(this, 'AppId');
+        // Lambda destination
+        const destination = new Queue(this, 'DestinationQueue');
+        ...
+```
+
+The destination is a location for Lambda to send events that could not be processed. It's only used if you invoke your function asynchronously, but it's useful here to show how you can modify your application's resources and function configuration.
+
+Commit the change and push.
+
+```bash
+my-application$ git commit -am "Add destination queue."
+my-application$ git push
+```
+
+**To see how the pipeline processes and deploys the change**
+
+1. Open the [Applications](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Deployments**.
+
+When the deployment is complete, view the application resources on the **Overview** tab to see the new resource.
+
+## Update the permissions boundary
+
+The sample application applies a **permissions boundary** to its function's execution role. The permissions boundary limits the permissions that you can add to the function's role. Without the boundary, users with write access to the project repository could modify the project template to give the function permission to access resources and services outside of the scope of the sample application.
+
+In order for the function to use the queue that you added in the previous step, you must extend the permissions boundary. The Lambda console detects resources that aren't in the permissions boundary and provides an updated policy that you can use to update it.
+
+**To update the application's permissions boundary**
+
+1. Open the [Applications](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Edit permissions boundary**.
+1. Follow the instructions shown to update the boundary to allow access to the new queue.
+
+## Update the function configuration
+
+Now you can grant the function permission to access the queue and configure the destinations setting.
+
+In the function's properties in `cdk/lib/cdk-stack.ts`, import the `@aws-cdk/aws-lambda-destinations` module and add an `SqsDestination` resource to the **onFailure** destinations configuration.
+
+```typescript
+import { SqsDestination } from '@aws-cdk/aws-lambda-destinations';
+import * as s3 from '@aws-cdk/aws-s3';
+import { Queue } from '@aws-cdk/aws-sqs';
+...
+
+// This is a Lambda function config associated with the source code: get-all-items.js
+const getAllItemsFunction = new lambda.Function(this, 'getAllItems', {
+    description: 'A simple example includes a HTTP get method to get all items from a DynamoDB table.',
+    handler: 'src/handlers/get-all-items.getAllItemsHandler',
+    runtime: lambda.Runtime.NODEJS_14_X,
+    code,
+    environment,
+    timeout: Duration.seconds(60),
+    onFailure: new SqsDestination(destination),
+});
+```
+
+Commit and push the change. When the deployment is complete, view the function in the console to see the updated configuration that specifies the destination.
+
+## Build and test locally
+
+The AWS SAM command line interface (CLI) is an extension of the AWS CLI that adds functionality for building and testing Lambda applications. It uses Docker to run your functions in an Amazon Linux environment that matches Lambda. It can also emulate your application's build environment and API.
+
+If you prefer to use an integrated development environment (IDE) to build and test your application, you can use the AWS Toolkit.
+The AWS Toolkit is an open-source plugin for popular IDEs that uses the AWS SAM CLI to build and deploy serverless applications on AWS. The AWS Toolkit also adds step-through debugging for Lambda function code.
+
+To get started, see the following:
+
+* [PyCharm](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [IntelliJ](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [VS Code](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html)
+* [Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/welcome.html)
+
+To use the AWS SAM CLI with this sample, you need the following tools:
+
+* AWS CLI - [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) and [configure it with your AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
+* AWS SAM CLI - [Install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html).
+* Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community).
+
+Compile your AWS CDK app and create a AWS CloudFormation template
+
+```bash
+my-application$ cd cdk
+cdk$ export S3_BUCKET=mockBucket
+cdk$ cdk synth --no-staging > ../template.yaml
+```
+
+Find the logical ID for your Lambda function in `template.yaml`. It will look like *putItem12345678*, where *12345678* represents an 8-character unique ID that the AWS CDK generates for all resources. The line right after it should look like `Type: AWS::Lambda::Function`.
+
+Test a single function by invoking it directly with a test event. An event is a JSON document that represents the input that the function receives from the event source. Test events are included in the `events` folder in this project.
+
+To invoke the function successfully, modify `env.json` to use correct function names and table name. Replace function names with ones generated in `template.yaml` and `<TABLE-NAME>` with the physical ID of the `SampleTable`. You can find the physical ID from the **Resources** section of the application overview in the Lambda console.
+
+Although functions in `template.yaml` are specified to have deployment package in S3, AWS SAM CLI assumes the source code is in the same local directory as `template.yaml`.
+
+Run functions locally and invoke them with the `sam local invoke` command.
+
+```bash
+my-application$ sam local invoke putItem12345678 --event events/event-post-item.json --env-vars env.json
+my-application$ sam local invoke getAllItems87654321 --event events/event-get-all-items.json --env-vars env.json
+```
+
+The AWS SAM CLI can also emulate your application's API. Use the `sam local start-api` command to run the API locally on port 3000.
+
+```bash
+my-application$ sam local start-api --env-vars env.json
+my-application$ curl http://localhost:3000/
+```
+
+## Unit tests
+
+Requirements:
+
+* Node.js - [Install Node.js 14.x](https://nodejs.org/en/), including the npm package management tool.
+
+Tests are defined in the \_\_tests__ folder in this project. Use `npm` to install the [Jest test framework](https://jestjs.io/) and run unit tests.
+
+```bash
+my-application$ npm install
+my-application$ npm run test
+```
+
+## Resources
+
+For an introduction to the AWS CDK specification, see the [AWS CDK Developer Guide](https://docs.aws.amazon.com/cdk/latest/guide/home.html).
+
+Next, you can use the AWS Serverless Application Repository to deploy ready-to-use apps that go beyond Hello World samples and learn how authors developed their applications. For more information, see the [AWS Serverless Application Repository main page](https://aws.amazon.com/serverless/serverlessrepo/) and the [AWS Serverless Application Repository Developer Guide](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/what-is-serverlessrepo.html).

--- a/nodejs14.x/serverless-api-backend/cdk/__tests__/unit/handlers/get-all-items.test.js
+++ b/nodejs14.x/serverless-api-backend/cdk/__tests__/unit/handlers/get-all-items.test.js
@@ -1,0 +1,47 @@
+// Import dynamodb from aws-sdk
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+// Import all functions from get-all-items.js
+const lambda = require('../../../src/handlers/get-all-items.js');
+
+// This includes all tests for getAllItemsHandler
+describe('Test getAllItemsHandler', () => {
+    let scanSpy;
+
+    // One-time setup and teardown, see more in https://jestjs.io/docs/en/setup-teardown
+    beforeAll(() => {
+        // Mock DynamoDB scan method
+        // https://jestjs.io/docs/en/jest-object.html#jestspyonobject-methodname
+        scanSpy = jest.spyOn(dynamodb.DocumentClient.prototype, 'scan');
+    });
+
+    // Clean up mocks
+    afterAll(() => {
+        scanSpy.mockRestore();
+    });
+
+    // This test invokes getAllItemsHandler and compares the result
+    it('should return ids', async () => {
+        const items = [{ id: 'id1' }, { id: 'id2' }];
+
+        // Return the specified value whenever the spied scan function is called
+        scanSpy.mockReturnValue({
+            promise: () => Promise.resolve({ Items: items }),
+        });
+
+        const event = {
+            httpMethod: 'GET',
+        };
+
+        // Invoke getAllItemsHandler
+        const result = await lambda.getAllItemsHandler(event);
+
+        const expectedResult = {
+            statusCode: 200,
+            body: JSON.stringify(items),
+        };
+
+        // Compare the result with the expected result
+        expect(result).toEqual(expectedResult);
+    });
+});

--- a/nodejs14.x/serverless-api-backend/cdk/__tests__/unit/handlers/get-by-id.test.js
+++ b/nodejs14.x/serverless-api-backend/cdk/__tests__/unit/handlers/get-by-id.test.js
@@ -1,0 +1,50 @@
+// Import dynamodb from aws-sdk
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+// Import all functions from get-by-id.js
+const lambda = require('../../../src/handlers/get-by-id.js');
+
+// This includes all tests for getByIdHandler
+describe('Test getByIdHandler', () => {
+    let getSpy;
+
+    // One-time setup and teardown, see more in https://jestjs.io/docs/en/setup-teardown
+    beforeAll(() => {
+        // Mock DynamoDB get method
+        // https://jestjs.io/docs/en/jest-object.html#jestspyonobject-methodname
+        getSpy = jest.spyOn(dynamodb.DocumentClient.prototype, 'get');
+    });
+
+    // Clean up mocks
+    afterAll(() => {
+        getSpy.mockRestore();
+    });
+
+    // This test invokes getByIdHandler and compares the result
+    it('should get item by id', async () => {
+        const item = { id: 'id1' };
+
+        // Return the specified value whenever the spied get function is called
+        getSpy.mockReturnValue({
+            promise: () => Promise.resolve({ Item: item }),
+        });
+
+        const event = {
+            httpMethod: 'GET',
+            pathParameters: {
+                id: 'id1',
+            },
+        };
+
+        // Invoke getByIdHandler
+        const result = await lambda.getByIdHandler(event);
+
+        const expectedResult = {
+            statusCode: 200,
+            body: JSON.stringify(item),
+        };
+
+        // Compare the result with the expected result
+        expect(result).toEqual(expectedResult);
+    });
+});

--- a/nodejs14.x/serverless-api-backend/cdk/__tests__/unit/handlers/put-item.test.js
+++ b/nodejs14.x/serverless-api-backend/cdk/__tests__/unit/handlers/put-item.test.js
@@ -1,0 +1,45 @@
+// Import dynamodb from aws-sdk
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+// Import all functions from put-item.js
+const lambda = require('../../../src/handlers/put-item.js');
+
+// This includes all tests for putItemHandler
+describe('Test putItemHandler', () => {
+    let putSpy;
+
+    // One-time setup and teardown, see more in https://jestjs.io/docs/en/setup-teardown
+    beforeAll(() => {
+        // Mock DynamoDB put method
+        // https://jestjs.io/docs/en/jest-object.html#jestspyonobject-methodname
+        putSpy = jest.spyOn(dynamodb.DocumentClient.prototype, 'put');
+    });
+
+    // Clean up mocks
+    afterAll(() => {
+        putSpy.mockRestore();
+    });
+
+    // This test invokes putItemHandler and compares the result
+    it('should add id to the table', async () => {
+        // Return the specified value whenever the spied put function is called
+        putSpy.mockReturnValue({
+            promise: () => Promise.resolve('data'),
+        });
+
+        const event = {
+            httpMethod: 'POST',
+            body: '{"id":"id1","name":"name1"}',
+        };
+
+        // Invoke putItemHandler()
+        const result = await lambda.putItemHandler(event);
+        const expectedResult = {
+            statusCode: 200,
+            body: event.body,
+        };
+
+        // Compare the result with the expected result
+        expect(result).toEqual(expectedResult);
+    });
+});

--- a/nodejs14.x/serverless-api-backend/cdk/buildspec.yml
+++ b/nodejs14.x/serverless-api-backend/cdk/buildspec.yml
@@ -1,0 +1,32 @@
+version: 0.2
+phases:
+  install:
+    commands:
+      # Install all dependencies (including dependencies for running tests)
+      - npm install
+      # Install CDK dependencies
+      - cd cdk
+      - npm install -g aws-cdk
+      - npm install
+      - cd ..
+  pre_build:
+    commands:
+      # Discover and run unit tests in the '__tests__' directory
+      - npm run test
+      # Remove all dependencies not needed for the Lambda deployment package (the packages from devDependencies in package.json)
+      - npm prune --production
+      # Copy artifacts to a separate folder
+      - mkdir function-code
+      - cp -r src node_modules function-code
+  build:
+    commands:
+      # Archive Lambda function code and upload it to S3
+      - cd function-code
+      - zip -r function-code.zip .
+      - aws s3 cp function-code.zip s3://$S3_BUCKET/$CODEBUILD_BUILD_ID/
+      # Use AWS CDK to synthesize the application
+      - cd ../cdk
+      - cdk synth > ../template-export.yml
+artifacts:
+  files:
+    - template-export.yml

--- a/nodejs14.x/serverless-api-backend/cdk/cdk/README.md
+++ b/nodejs14.x/serverless-api-backend/cdk/cdk/README.md
@@ -1,0 +1,8 @@
+# Useful commands
+
+ * `npm run build`   compile typescript to js
+ * `npm run watch`   watch for changes and compile
+ * `npm run test`    perform the jest unit tests
+ * `cdk deploy`      deploy this stack to your default AWS account/region
+ * `cdk diff`        compare deployed stack with current state
+ * `cdk synth`       emits the synthesized CloudFormation template

--- a/nodejs14.x/serverless-api-backend/cdk/cdk/bin/cdk.ts
+++ b/nodejs14.x/serverless-api-backend/cdk/cdk/bin/cdk.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import { App, Aws } from '@aws-cdk/core';
+
+import { CdkStack } from '../lib/cdk-stack';
+import { PermissionsBoundaryAspect } from '../lib/permissions-boundary-aspect';
+
+
+const stack = new CdkStack(new App(), 'CdkStack', { description: 'Website &amp; Mobile Starter Project' });
+const { ACCOUNT_ID, PARTITION, REGION, STACK_NAME } = Aws;
+const permissionBoundaryArn = `arn:${PARTITION}:iam::${ACCOUNT_ID}:policy/${STACK_NAME}-${REGION}-PermissionsBoundary`;
+
+// Apply permissions boundary to the stack
+stack.node.applyAspect(new PermissionsBoundaryAspect(permissionBoundaryArn));

--- a/nodejs14.x/serverless-api-backend/cdk/cdk/cdk.json
+++ b/nodejs14.x/serverless-api-backend/cdk/cdk/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "npx ts-node bin/cdk.ts"
+}

--- a/nodejs14.x/serverless-api-backend/cdk/cdk/jest.config.js
+++ b/nodejs14.x/serverless-api-backend/cdk/cdk/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+    'roots': [
+        '<rootDir>/test'
+    ],
+    testMatch: ['**/*.test.ts'],
+    'transform': {
+        '^.+\\.tsx?$': 'ts-jest'
+    },
+};

--- a/nodejs14.x/serverless-api-backend/cdk/cdk/lib/cdk-stack.ts
+++ b/nodejs14.x/serverless-api-backend/cdk/cdk/lib/cdk-stack.ts
@@ -1,0 +1,68 @@
+import * as apigateway from '@aws-cdk/aws-apigateway';
+import * as dynamodb from '@aws-cdk/aws-dynamodb';
+import * as lambda from '@aws-cdk/aws-lambda';
+import * as s3 from '@aws-cdk/aws-s3';
+import { App, CfnParameter, Duration, Stack, StackProps } from '@aws-cdk/core';
+
+
+export class CdkStack extends Stack {
+    constructor(scope: App, id: string, props: StackProps) {
+        super(scope, id, props);
+
+        new CfnParameter(this, 'AppId');
+
+        // DynamoDB table to store item: {id: <ID>, name: <NAME>}
+        const table = new dynamodb.Table(this, 'SampleTable', {
+            partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
+            readCapacity: 2,
+            writeCapacity: 2
+        });
+
+        const environment = { SAMPLE_TABLE: table.tableName };
+        // The code will be uploaded to this location during the pipeline's build step
+        const artifactBucket = s3.Bucket.fromBucketName(this, 'ArtifactBucket', process.env.S3_BUCKET!);
+        const artifactKey = `${process.env.CODEBUILD_BUILD_ID}/function-code.zip`;
+        const code = lambda.Code.fromBucket(artifactBucket, artifactKey);
+
+        // This is a Lambda function config associated with the source code: get-all-items.js
+        const getAllItemsFunction = new lambda.Function(this, 'getAllItems', {
+            description: 'A simple example includes a HTTP get method to get all items from a DynamoDB table.',
+            handler: 'src/handlers/get-all-items.getAllItemsHandler',
+            runtime: lambda.Runtime.NODEJS_14_X,
+            code,
+            environment,
+            timeout: Duration.seconds(60),
+        });
+        // Give Read permissions to the SampleTable
+        table.grantReadData(getAllItemsFunction);
+
+        // This is a Lambda function config associated with the source code: get-by-id.js
+        const getByIdFunction = new lambda.Function(this, 'getById', {
+            description: 'A simple example includes a HTTP get method to get one item by id from a DynamoDB table.',
+            handler: 'src/handlers/get-by-id.getByIdHandler',
+            runtime: lambda.Runtime.NODEJS_14_X,
+            code,
+            timeout: Duration.seconds(60),
+            environment,
+        });
+        // Give Read permissions to the SampleTable
+        table.grantReadData(getByIdFunction);
+
+        // This is a Lambda function config associated with the source code: put-item.js
+        const putItemFunction = new lambda.Function(this, 'putItem', {
+            description: 'A simple example includes a HTTP post method to add one item to a DynamoDB table.',
+            handler: 'src/handlers/put-item.putItemHandler',
+            runtime: lambda.Runtime.NODEJS_14_X,
+            code,
+            timeout: Duration.seconds(60),
+            environment,
+        });
+        // Give Create/Read/Update/Delete permissions to the SampleTable
+        table.grantReadWriteData(putItemFunction);
+
+        const api = new apigateway.RestApi(this, 'ServerlessRestApi', { cloudWatchRole: false });
+        api.root.addMethod('GET', new apigateway.LambdaIntegration(getAllItemsFunction));
+        api.root.addMethod('POST', new apigateway.LambdaIntegration(putItemFunction));
+        api.root.addResource('{id}').addMethod('GET', new apigateway.LambdaIntegration(getByIdFunction));
+    }
+}

--- a/nodejs14.x/serverless-api-backend/cdk/cdk/lib/permissions-boundary-aspect.ts
+++ b/nodejs14.x/serverless-api-backend/cdk/cdk/lib/permissions-boundary-aspect.ts
@@ -1,0 +1,18 @@
+import * as iam from '@aws-cdk/aws-iam';
+import { IAspect, IConstruct } from '@aws-cdk/core';
+
+
+export class PermissionsBoundaryAspect implements IAspect {
+    private readonly arn: string;
+
+    constructor(permissionBoundaryArn: string) {
+        this.arn = permissionBoundaryArn;
+    }
+
+    public visit(node: IConstruct): void {
+        if (node instanceof iam.Role) {
+            const roleResource = node.node.findChild('Resource') as iam.CfnRole;
+            roleResource.addPropertyOverride('PermissionsBoundary', this.arn);
+        }
+    }
+}

--- a/nodejs14.x/serverless-api-backend/cdk/cdk/package.json
+++ b/nodejs14.x/serverless-api-backend/cdk/cdk/package.json
@@ -1,0 +1,30 @@
+{
+    "name": "lambda-api-backend-cdk",
+    "version": "0.0.1",
+    "bin": {
+        "cdk": "bin/cdk.js"
+    },
+    "scripts": {
+        "build": "tsc",
+        "watch": "tsc -w",
+        "test": "jest",
+        "cdk": "cdk"
+    },
+    "devDependencies": {
+        "@aws-cdk/assert": "^1.31.0",
+        "@types/jest": "^25.2.1",
+        "@types/node": "^10.17.5",
+        "aws-cdk": "^1.31.0",
+        "jest": "^25.4.0",
+        "ts-jest": "^25.4.0",
+        "ts-node": "^8.9.0",
+        "typescript": "^3.8.3"
+    },
+    "dependencies": {
+        "@aws-cdk/aws-apigateway": "^1.31.0",
+        "@aws-cdk/aws-dynamodb": "^1.31.0",
+        "@aws-cdk/aws-lambda": "^1.31.0",
+        "@aws-cdk/aws-s3": "^1.31.0",
+        "@aws-cdk/core": "^1.31.0"
+    }
+}

--- a/nodejs14.x/serverless-api-backend/cdk/cdk/package.json
+++ b/nodejs14.x/serverless-api-backend/cdk/cdk/package.json
@@ -13,7 +13,7 @@
     "devDependencies": {
         "@aws-cdk/assert": "^1.31.0",
         "@types/jest": "^25.2.1",
-        "@types/node": "^10.17.5",
+        "@types/node": "^14.17.5",
         "aws-cdk": "^1.31.0",
         "jest": "^25.4.0",
         "ts-jest": "^25.4.0",

--- a/nodejs14.x/serverless-api-backend/cdk/cdk/tsconfig.json
+++ b/nodejs14.x/serverless-api-backend/cdk/cdk/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "target": "ES2018",
+        "module": "commonjs",
+        "lib": [
+            "es2016",
+            "es2017.object",
+            "es2017.string"
+        ],
+        "declaration": true,
+        "strict": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "noImplicitThis": true,
+        "alwaysStrict": true,
+        "noUnusedLocals": false,
+        "noUnusedParameters": false,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": false,
+        "inlineSourceMap": true,
+        "inlineSources": true,
+        "experimentalDecorators": true,
+        "strictPropertyInitialization": false,
+        "typeRoots": [
+            "./node_modules/@types"
+        ]
+    },
+    "exclude": [
+        "cdk.out"
+    ]
+}

--- a/nodejs14.x/serverless-api-backend/cdk/env.json
+++ b/nodejs14.x/serverless-api-backend/cdk/env.json
@@ -1,0 +1,11 @@
+{
+    "getAllItems": {
+        "SAMPLE_TABLE": "<TABLE-NAME>"
+    },
+    "getById": {
+        "SAMPLE_TABLE": "<TABLE-NAME>"
+    },
+    "putItem": {
+        "SAMPLE_TABLE": "<TABLE-NAME>"
+    }
+}

--- a/nodejs14.x/serverless-api-backend/cdk/events/event-get-all-items.json
+++ b/nodejs14.x/serverless-api-backend/cdk/events/event-get-all-items.json
@@ -1,0 +1,3 @@
+{
+    "httpMethod": "GET"
+}

--- a/nodejs14.x/serverless-api-backend/cdk/events/event-get-by-id.json
+++ b/nodejs14.x/serverless-api-backend/cdk/events/event-get-by-id.json
@@ -1,0 +1,6 @@
+{
+    "httpMethod": "GET",
+    "pathParameters": {
+        "id": "id1"
+    }
+}

--- a/nodejs14.x/serverless-api-backend/cdk/events/event-post-item.json
+++ b/nodejs14.x/serverless-api-backend/cdk/events/event-post-item.json
@@ -1,0 +1,4 @@
+{
+    "httpMethod": "POST",
+    "body": "{\"id\": \"id1\",\"name\": \"name1\"}"
+}

--- a/nodejs14.x/serverless-api-backend/cdk/package.json
+++ b/nodejs14.x/serverless-api-backend/cdk/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "lambda-api-backend",
+    "description": "Website & Mobile Starter Project",
+    "version": "0.0.1",
+    "private": true,
+    "dependencies": {
+        "aws-sdk": "^2.660.0"
+    },
+    "devDependencies": {
+        "jest": "^25.4.0"
+    },
+    "scripts": {
+        "test": "jest"
+    }
+}

--- a/nodejs14.x/serverless-api-backend/cdk/src/handlers/get-all-items.js
+++ b/nodejs14.x/serverless-api-backend/cdk/src/handlers/get-all-items.js
@@ -1,0 +1,36 @@
+// Create clients and set shared const values outside of the handler
+
+// Create a DocumentClient that represents the query to get all items
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+const docClient = new dynamodb.DocumentClient();
+
+// Get the DynamoDB table name from environment variables
+const tableName = process.env.SAMPLE_TABLE;
+
+/**
+ * A simple example includes a HTTP get method to get all items from a DynamoDB table.
+ */
+exports.getAllItemsHandler = async (event) => {
+    const { httpMethod, path } = event;
+    if (httpMethod !== 'GET') {
+        throw new Error(`getAllItems only accept GET method, you tried: ${httpMethod}`);
+    }
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    console.log('received:', JSON.stringify(event));
+
+    // get all items from the table (only first 1MB data, you can use `LastEvaluatedKey` to get the rest of data)
+    // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#scan-property
+    // https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html
+    const params = { TableName: tableName };
+    const { Items } = await docClient.scan(params).promise();
+
+    const response = {
+        statusCode: 200,
+        body: JSON.stringify(Items),
+    };
+
+    console.log(`response from: ${path} statusCode: ${response.statusCode} body: ${response.body}`);
+    return response;
+};

--- a/nodejs14.x/serverless-api-backend/cdk/src/handlers/get-by-id.js
+++ b/nodejs14.x/serverless-api-backend/cdk/src/handlers/get-by-id.js
@@ -1,0 +1,41 @@
+// Create clients and set shared const values outside of the handler
+
+// Create a DocumentClient that represents the query to get an item
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+const docClient = new dynamodb.DocumentClient();
+
+// Get the DynamoDB table name from environment variables
+const tableName = process.env.SAMPLE_TABLE;
+
+/**
+ * A simple example includes a HTTP get method to get one item by id from a DynamoDB table.
+ */
+exports.getByIdHandler = async (event) => {
+    const { httpMethod, path, pathParameters } = event;
+    if (httpMethod !== 'GET') {
+        throw new Error(`getMethod only accept GET method, you tried: ${httpMethod}`);
+    }
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    console.log('received:', JSON.stringify(event));
+
+    // Get id from pathParameters from APIGateway because of `/{id}` at template.yml
+    const { id } = pathParameters;
+
+    // Get the item from the table
+    // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#get-property
+    const params = {
+        TableName: tableName,
+        Key: { id },
+    };
+    const { Item } = await docClient.get(params).promise();
+
+    const response = {
+        statusCode: 200,
+        body: JSON.stringify(Item),
+    };
+
+    console.log(`response from: ${path} statusCode: ${response.statusCode} body: ${response.body}`);
+    return response;
+};

--- a/nodejs14.x/serverless-api-backend/cdk/src/handlers/put-item.js
+++ b/nodejs14.x/serverless-api-backend/cdk/src/handlers/put-item.js
@@ -1,0 +1,41 @@
+// Create clients and set shared const values outside of the handler
+
+// Create a DocumentClient that represents the query to add an item
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+const docClient = new dynamodb.DocumentClient();
+
+// Get the DynamoDB table name from environment variables
+const tableName = process.env.SAMPLE_TABLE;
+
+/**
+ * A simple example includes a HTTP post method to add one item to a DynamoDB table.
+ */
+exports.putItemHandler = async (event) => {
+    const { body, httpMethod, path } = event;
+    if (httpMethod !== 'POST') {
+        throw new Error(`postMethod only accepts POST method, you tried: ${httpMethod} method.`);
+    }
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    console.log('received:', JSON.stringify(event));
+
+    // Get id and name from the body of the request
+    const { id, name } = JSON.parse(body);
+
+    // Creates a new item, or replaces an old item with a new item
+    // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#put-property
+    const params = {
+        TableName: tableName,
+        Item: { id, name },
+    };
+    await docClient.put(params).promise();
+
+    const response = {
+        statusCode: 200,
+        body,
+    };
+
+    console.log(`response from: ${path} statusCode: ${response.statusCode} body: ${response.body}`);
+    return response;
+};

--- a/nodejs14.x/serverless-api-backend/sam/.gitignore
+++ b/nodejs14.x/serverless-api-backend/sam/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/nodejs14.x/serverless-api-backend/sam/README.md
+++ b/nodejs14.x/serverless-api-backend/sam/README.md
@@ -1,0 +1,191 @@
+# Website & Mobile Starter Project
+
+This project contains source code and supporting files for the serverless application that you created in the AWS Lambda console. You can update your application at any time by committing and pushing changes to your AWS CodeCommit or GitHub repository.
+
+This project includes the following files and folders:
+
+- src - Code for the application's Lambda function.
+- events - Invocation events that you can use to invoke the function.
+- \_\_tests__ - Unit tests for the application code.
+- template.yml - A SAM template that defines the application's AWS resources.
+- buildspec.yml -  A build specification file that tells AWS CodeBuild how to create a deployment package for the function.
+
+Your Lambda application includes two AWS CloudFormation stacks. The first stack creates the pipeline that builds and deploys your application.
+
+The pipeline creates a second stack that contains your application's resources, including Lambda functions, an API Gateway API, and Amazon DynamoDB tables. These resources are defined in the `template.yml` file in this project. You can update the template to add AWS resources through the same deployment process that updates your application code. You can view those resources in the **Resources** section of the application overview in the Lambda console.
+
+For a full list of possible operations, see the [AWS Lambda Applications documentation](https://docs.aws.amazon.com/lambda/latest/dg/deploying-lambda-apps.html).
+
+## Try the application out
+
+The sample application creates a RESTful API that takes HTTP requests and invokes Lambda functions. The API has POST and GET methods on the root path to create and list items. It has a GET method that takes an ID path parameter to retrieve items. Each method maps to one of the application's three Lambda functions.
+
+**To use the sample API**
+
+1. Choose your application from the [**Applications page**](https://console.aws.amazon.com/lambda/home#/applications) in the Lambda console. (Make sure you're in the right region)
+1. Copy the URL that's listed under **API endpoint**.
+1. At the command line, use cURL to send POST requests to the application endpoint.
+
+        $ ENDPOINT=<paste-your-endpoint-here>
+        $ curl -d '{"id":"1234ABCD", "name":"My item"}' -H "Content-Type: application/json" -X POST $ENDPOINT
+        {"id":"1234ABCD","name":"My item"}
+        $ curl -d '{"id":"2234ABCD", "name":"My other item"}' -H "Content-Type: application/json" -X POST $ENDPOINT
+        {"id":"2234ABCD","name":"My other item"}
+
+1. Send a GET request to the endpoint to get a list of items.
+
+        $ curl $ENDPOINT
+        [{"id":"1234ABCD","name":"My item"},{"id":"2234ABCD","name":"My other item"}]
+
+1. Send a GET request with the item ID to get a single item.
+
+        $ curl $ENDPOINT/1234ABCD
+        {"id":"1234ABCD","name":"My item"}
+
+To view the application's API, functions, and table, use the links in the **Resources** section of the application overview in the Lambda console.
+
+## Add a resource to your application
+
+The application template uses the AWS Serverless Application Model (AWS SAM) to define application resources. AWS SAM is an extension of AWS CloudFormation with a simpler syntax for configuring common serverless application resources, such as functions, triggers, and APIs. For resources that aren't included in the [AWS SAM specification](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md), you can use the standard [AWS CloudFormation resource types](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html).
+
+Update `template.yml` to add a dead-letter queue to your application. In the **Resources** section, add a resource named **MyQueue** with the type **AWS::SQS::Queue**.
+
+```
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+```
+
+The dead-letter queue is a location for Lambda to send events that could not be processed. It's only used if you invoke your function asynchronously, but it's useful here to show how you can modify your application's resources and function configuration.
+
+Commit the change and push.
+
+```bash
+my-application$ git commit -am "Add dead-letter queue."
+my-application$ git push
+```
+
+**To see how the pipeline processes and deploys the change**
+
+1. Open the [**Applications**](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Deployments**.
+
+When the deployment completes, view the application resources on the **Overview** tab to see the new resource.
+
+## Update the permissions boundary
+
+The sample application applies a **permissions boundary** to its function's execution role. The permissions boundary limits the permissions that you can add to the function's role. Without the boundary, users with write access to the project repository could modify the project template to give the function permission to access resources and services outside of the scope of the sample application.
+
+In order for the function to use the queue that you added in the previous step, you must extend the permissions boundary. The Lambda console detects resources that aren't in the permissions boundary and provides an updated policy that you can use to update it.
+
+**To update the application's permissions boundary**
+
+1. Open the [**Applications**](https://console.aws.amazon.com/lambda/home#/applications) page.
+1. Choose your application.
+1. Choose **Edit permissions boundary**.
+1. Follow the instructions shown to update the boundary to allow access to the new queue.
+
+## Update the function configuration
+
+Now you can grant the function permission to access the queue and configure the dead-letter queue setting.
+
+In the function's properties in `template.yml`, add the **DeadLetterQueue** configuration. Under Policies, add **SQSSendMessagePolicy**. **SQSSendMessagePolicy** is a [policy template](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-policy-templates.html) that grants the function permission to send messages to a queue.
+
+```
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+  getAllItemsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: src/handlers/get-all-items.getAllItemsHandler
+      Runtime: nodejs14.x
+      MemorySize: 128
+      Timeout: 60
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !GetAtt MyQueue.Arn
+      Policies:
+        - SQSSendMessagePolicy:
+            QueueName: !GetAtt MyQueue.QueueName
+        - DynamoDBCrudPolicy:
+            TableName: !Ref SampleTable
+```
+
+Commit and push the change. When the deployment completes, view the function in the console to see the updated configuration that specifies the dead-letter queue.
+
+## Build and test locally
+
+The AWS SAM command line interface (CLI) is an extension of the AWS CLI that adds functionality for building and testing Lambda applications. It uses Docker to run your functions in an Amazon Linux environment that matches Lambda. It can also emulate your application's build environment and API.
+
+If you prefer to use an integrated development environment (IDE) to build and test your application, you can use the AWS Toolkit.
+The AWS Toolkit is an open-source plugin for popular IDEs that uses the AWS SAM CLI to build and deploy serverless applications on AWS. The AWS Toolkit also adds step-through debugging for Lambda function code.
+
+To get started, see the following:
+
+* [PyCharm](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [IntelliJ](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [VS Code](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html)
+* [Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/welcome.html)
+
+To use the AWS SAM CLI with this sample, you need the following tools:
+
+* AWS CLI - [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) and [configure it with your AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
+* AWS SAM CLI - [Install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html).
+* Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community).
+
+Build your application with the `sam build` command.
+
+```bash
+my-application$ sam build -m package.json
+```
+
+The AWS SAM CLI installs dependencies that are defined in `package.json`, creates a deployment package, and saves its contents in the `.aws-sam/build` folder.
+
+Test a single function by invoking it directly with a test event. An event is a JSON document that represents the input that the function receives from the event source. Test events are included in the `events` folder in this project.
+
+Run functions locally and invoke them with the `sam local invoke` command.
+
+```bash
+my-application$ sam local invoke putItemFunction --event events/event-post-item.json
+my-application$ sam local invoke getAllItemsFunction --event events/event-get-all-items.json
+```
+
+The AWS SAM CLI can also emulate your application's API. Use the `sam local start-api` command to run the API locally on port 3000.
+
+```bash
+my-application$ sam local start-api
+my-application$ curl http://localhost:3000/
+```
+
+The AWS SAM CLI reads the application template to determine the API's routes and the functions that they invoke. The `Events` property on each function's definition includes the route and method for each path.
+
+```yaml
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /
+            Method: GET
+```
+
+## Unit tests
+
+Requirements:
+
+* Node.js - [Install Node.js 14.x](https://nodejs.org/en/), including the npm package management tool.
+
+Tests are defined in the \_\_tests__ folder in this project. Use `npm` to install the [Jest test framework](https://jestjs.io/) and run unit tests.
+
+```bash
+my-application$ npm install
+my-application$ npm run test
+```
+
+## Resources
+
+For an introduction to the AWS SAM specification, the AWS SAM CLI, and serverless application concepts, see the [AWS SAM Developer Guide](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html).
+
+Next, you can use the AWS Serverless Application Repository to deploy ready-to-use apps that go beyond Hello World samples and learn how authors developed their applications. For more information, see the [AWS Serverless Application Repository main page](https://aws.amazon.com/serverless/serverlessrepo/) and the [AWS Serverless Application Repository Developer Guide](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/what-is-serverlessrepo.html).

--- a/nodejs14.x/serverless-api-backend/sam/__tests__/unit/handlers/get-all-items.test.js
+++ b/nodejs14.x/serverless-api-backend/sam/__tests__/unit/handlers/get-all-items.test.js
@@ -1,0 +1,47 @@
+// Import dynamodb from aws-sdk
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+// Import all functions from get-all-items.js
+const lambda = require('../../../src/handlers/get-all-items.js');
+
+// This includes all tests for getAllItemsHandler
+describe('Test getAllItemsHandler', () => {
+    let scanSpy;
+
+    // One-time setup and teardown, see more in https://jestjs.io/docs/en/setup-teardown
+    beforeAll(() => {
+        // Mock DynamoDB scan method
+        // https://jestjs.io/docs/en/jest-object.html#jestspyonobject-methodname
+        scanSpy = jest.spyOn(dynamodb.DocumentClient.prototype, 'scan');
+    });
+
+    // Clean up mocks
+    afterAll(() => {
+        scanSpy.mockRestore();
+    });
+
+    // This test invokes getAllItemsHandler and compares the result
+    it('should return ids', async () => {
+        const items = [{ id: 'id1' }, { id: 'id2' }];
+
+        // Return the specified value whenever the spied scan function is called
+        scanSpy.mockReturnValue({
+            promise: () => Promise.resolve({ Items: items }),
+        });
+
+        const event = {
+            httpMethod: 'GET',
+        };
+
+        // Invoke getAllItemsHandler
+        const result = await lambda.getAllItemsHandler(event);
+
+        const expectedResult = {
+            statusCode: 200,
+            body: JSON.stringify(items),
+        };
+
+        // Compare the result with the expected result
+        expect(result).toEqual(expectedResult);
+    });
+});

--- a/nodejs14.x/serverless-api-backend/sam/__tests__/unit/handlers/get-by-id.test.js
+++ b/nodejs14.x/serverless-api-backend/sam/__tests__/unit/handlers/get-by-id.test.js
@@ -1,0 +1,50 @@
+// Import dynamodb from aws-sdk
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+// Import all functions from get-by-id.js
+const lambda = require('../../../src/handlers/get-by-id.js');
+
+// This includes all tests for getByIdHandler
+describe('Test getByIdHandler', () => {
+    let getSpy;
+
+    // One-time setup and teardown, see more in https://jestjs.io/docs/en/setup-teardown
+    beforeAll(() => {
+        // Mock DynamoDB get method
+        // https://jestjs.io/docs/en/jest-object.html#jestspyonobject-methodname
+        getSpy = jest.spyOn(dynamodb.DocumentClient.prototype, 'get');
+    });
+
+    // Clean up mocks
+    afterAll(() => {
+        getSpy.mockRestore();
+    });
+
+    // This test invokes getByIdHandler and compares the result
+    it('should get item by id', async () => {
+        const item = { id: 'id1' };
+
+        // Return the specified value whenever the spied get function is called
+        getSpy.mockReturnValue({
+            promise: () => Promise.resolve({ Item: item }),
+        });
+
+        const event = {
+            httpMethod: 'GET',
+            pathParameters: {
+                id: 'id1',
+            },
+        };
+
+        // Invoke getByIdHandler
+        const result = await lambda.getByIdHandler(event);
+
+        const expectedResult = {
+            statusCode: 200,
+            body: JSON.stringify(item),
+        };
+
+        // Compare the result with the expected result
+        expect(result).toEqual(expectedResult);
+    });
+});

--- a/nodejs14.x/serverless-api-backend/sam/__tests__/unit/handlers/put-item.test.js
+++ b/nodejs14.x/serverless-api-backend/sam/__tests__/unit/handlers/put-item.test.js
@@ -1,0 +1,45 @@
+// Import dynamodb from aws-sdk
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+// Import all functions from put-item.js
+const lambda = require('../../../src/handlers/put-item.js');
+
+// This includes all tests for putItemHandler
+describe('Test putItemHandler', () => {
+    let putSpy;
+
+    // One-time setup and teardown, see more in https://jestjs.io/docs/en/setup-teardown
+    beforeAll(() => {
+        // Mock DynamoDB put method
+        // https://jestjs.io/docs/en/jest-object.html#jestspyonobject-methodname
+        putSpy = jest.spyOn(dynamodb.DocumentClient.prototype, 'put');
+    });
+
+    // Clean up mocks
+    afterAll(() => {
+        putSpy.mockRestore();
+    });
+
+    // This test invokes putItemHandler and compares the result
+    it('should add id to the table', async () => {
+        // Return the specified value whenever the spied put function is called
+        putSpy.mockReturnValue({
+            promise: () => Promise.resolve('data'),
+        });
+
+        const event = {
+            httpMethod: 'POST',
+            body: '{"id":"id1","name":"name1"}',
+        };
+
+        // Invoke putItemHandler()
+        const result = await lambda.putItemHandler(event);
+        const expectedResult = {
+            statusCode: 200,
+            body: event.body,
+        };
+
+        // Compare the result with the expected result
+        expect(result).toEqual(expectedResult);
+    });
+});

--- a/nodejs14.x/serverless-api-backend/sam/buildspec.yml
+++ b/nodejs14.x/serverless-api-backend/sam/buildspec.yml
@@ -1,0 +1,22 @@
+version: 0.2
+phases:
+  install:
+    commands:
+      # Install all dependencies (including dependencies for running tests)
+      - npm install
+  pre_build:
+    commands:
+      # Discover and run unit tests in the '__tests__' directory
+      - npm run test
+      # Remove all unit tests to reduce the size of the package that will be ultimately uploaded to Lambda
+      - rm -rf ./__tests__
+      # Remove all dependencies not needed for the Lambda deployment package (the packages from devDependencies in package.json)
+      - npm prune --production
+  build:
+    commands:
+      # Use AWS SAM to package the application by using AWS CloudFormation
+      - aws cloudformation package --template template.yml --s3-bucket $S3_BUCKET --output-template template-export.yml
+artifacts:
+  type: zip
+  files:
+    - template-export.yml

--- a/nodejs14.x/serverless-api-backend/sam/env.json
+++ b/nodejs14.x/serverless-api-backend/sam/env.json
@@ -1,0 +1,11 @@
+{
+    "getAllItemsFunction": {
+        "SAMPLE_TABLE": "<TABLE-NAME>"
+    },
+    "getByIdFunction": {
+        "SAMPLE_TABLE": "<TABLE-NAME>"
+    },
+    "putItemFunction": {
+        "SAMPLE_TABLE": "<TABLE-NAME>"
+    }
+  }

--- a/nodejs14.x/serverless-api-backend/sam/events/event-get-all-items.json
+++ b/nodejs14.x/serverless-api-backend/sam/events/event-get-all-items.json
@@ -1,0 +1,3 @@
+{
+    "httpMethod": "GET"
+}

--- a/nodejs14.x/serverless-api-backend/sam/events/event-get-by-id.json
+++ b/nodejs14.x/serverless-api-backend/sam/events/event-get-by-id.json
@@ -1,0 +1,6 @@
+{
+    "httpMethod": "GET",
+    "pathParameters": {
+        "id": "id1"
+    }
+}

--- a/nodejs14.x/serverless-api-backend/sam/events/event-post-item.json
+++ b/nodejs14.x/serverless-api-backend/sam/events/event-post-item.json
@@ -1,0 +1,4 @@
+{
+    "httpMethod": "POST",
+    "body": "{\"id\": \"id1\",\"name\": \"name1\"}"
+}

--- a/nodejs14.x/serverless-api-backend/sam/package.json
+++ b/nodejs14.x/serverless-api-backend/sam/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "lambda-api-backend",
+    "description": "Website & Mobile Starter Project",
+    "version": "0.0.1",
+    "private": true,
+    "dependencies": {
+        "aws-sdk": "^2.437.0"
+    },
+    "devDependencies": {
+        "jest": "^24.7.1"
+    },
+    "scripts": {
+        "test": "jest"
+    }
+}

--- a/nodejs14.x/serverless-api-backend/sam/src/handlers/get-all-items.js
+++ b/nodejs14.x/serverless-api-backend/sam/src/handlers/get-all-items.js
@@ -1,0 +1,36 @@
+// Create clients and set shared const values outside of the handler
+
+// Create a DocumentClient that represents the query to get all items
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+const docClient = new dynamodb.DocumentClient();
+
+// Get the DynamoDB table name from environment variables
+const tableName = process.env.SAMPLE_TABLE;
+
+/**
+ * A simple example includes a HTTP get method to get all items from a DynamoDB table.
+ */
+exports.getAllItemsHandler = async (event) => {
+    const { httpMethod, path } = event;
+    if (httpMethod !== 'GET') {
+        throw new Error(`getAllItems only accept GET method, you tried: ${httpMethod}`);
+    }
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    console.log('received:', JSON.stringify(event));
+
+    // get all items from the table (only first 1MB data, you can use `LastEvaluatedKey` to get the rest of data)
+    // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#scan-property
+    // https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html
+    const params = { TableName: tableName };
+    const { Items } = await docClient.scan(params).promise();
+
+    const response = {
+        statusCode: 200,
+        body: JSON.stringify(Items),
+    };
+
+    console.log(`response from: ${path} statusCode: ${response.statusCode} body: ${response.body}`);
+    return response;
+};

--- a/nodejs14.x/serverless-api-backend/sam/src/handlers/get-by-id.js
+++ b/nodejs14.x/serverless-api-backend/sam/src/handlers/get-by-id.js
@@ -1,0 +1,41 @@
+// Create clients and set shared const values outside of the handler
+
+// Create a DocumentClient that represents the query to get an item
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+const docClient = new dynamodb.DocumentClient();
+
+// Get the DynamoDB table name from environment variables
+const tableName = process.env.SAMPLE_TABLE;
+
+/**
+ * A simple example includes a HTTP get method to get one item by id from a DynamoDB table.
+ */
+exports.getByIdHandler = async (event) => {
+    const { httpMethod, path, pathParameters } = event;
+    if (httpMethod !== 'GET') {
+        throw new Error(`getMethod only accept GET method, you tried: ${httpMethod}`);
+    }
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    console.log('received:', JSON.stringify(event));
+
+    // Get id from pathParameters from APIGateway because of `/{id}` at template.yml
+    const { id } = pathParameters;
+
+    // Get the item from the table
+    // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#get-property
+    const params = {
+        TableName: tableName,
+        Key: { id },
+    };
+    const { Item } = await docClient.get(params).promise();
+
+    const response = {
+        statusCode: 200,
+        body: JSON.stringify(Item),
+    };
+
+    console.log(`response from: ${path} statusCode: ${response.statusCode} body: ${response.body}`);
+    return response;
+};

--- a/nodejs14.x/serverless-api-backend/sam/src/handlers/put-item.js
+++ b/nodejs14.x/serverless-api-backend/sam/src/handlers/put-item.js
@@ -1,0 +1,41 @@
+// Create clients and set shared const values outside of the handler
+
+// Create a DocumentClient that represents the query to add an item
+const dynamodb = require('aws-sdk/clients/dynamodb');
+
+const docClient = new dynamodb.DocumentClient();
+
+// Get the DynamoDB table name from environment variables
+const tableName = process.env.SAMPLE_TABLE;
+
+/**
+ * A simple example includes a HTTP post method to add one item to a DynamoDB table.
+ */
+exports.putItemHandler = async (event) => {
+    const { body, httpMethod, path } = event;
+    if (httpMethod !== 'POST') {
+        throw new Error(`postMethod only accepts POST method, you tried: ${httpMethod} method.`);
+    }
+    // All log statements are written to CloudWatch by default. For more information, see
+    // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
+    console.log('received:', JSON.stringify(event));
+
+    // Get id and name from the body of the request
+    const { id, name } = JSON.parse(body);
+
+    // Creates a new item, or replaces an old item with a new item
+    // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#put-property
+    const params = {
+        TableName: tableName,
+        Item: { id, name },
+    };
+    await docClient.put(params).promise();
+
+    const response = {
+        statusCode: 200,
+        body,
+    };
+
+    console.log(`response from: ${path} statusCode: ${response.statusCode} body: ${response.body}`);
+    return response;
+};

--- a/nodejs14.x/serverless-api-backend/sam/template.yml
+++ b/nodejs14.x/serverless-api-backend/sam/template.yml
@@ -1,0 +1,124 @@
+# This is the SAM template that represents the architecture of your serverless application
+# https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-template-basics.html
+
+# The AWSTemplateFormatVersion identifies the capabilities of the template
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/format-version-structure.html
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Website & Mobile Starter Project
+
+# Transform section specifies one or more macros that AWS CloudFormation uses to process your template
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-section-structure.html
+Transform: AWS::Serverless-2016-10-31
+
+# Shared configuration for all resources, more in
+# https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
+Globals:
+  Function:
+    # The PermissionsBoundary allows users to safely develop with their function's permissions constrained
+    # to their current application. All the functions and roles in this application have to include it and
+    # it has to be manually updated when you add resources to your application.
+    # More information in https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html
+    PermissionsBoundary: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/${AppId}-${AWS::Region}-PermissionsBoundary'
+
+Parameters:
+  AppId:
+    Type: String
+
+# Resources declares the AWS resources that you want to include in the stack
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html
+Resources:
+  # Each Lambda function is defined by properties:
+  # https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+
+  # This is a Lambda function config associated with the source code: get-all-items.js
+  getAllItemsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: src/handlers/get-all-items.getAllItemsHandler
+      Runtime: nodejs14.x
+      MemorySize: 128
+      Timeout: 60
+      Description: A simple example includes a HTTP get method to get all items from a DynamoDB table.
+      Policies:
+        # Give Create/Read/Update/Delete Permissions to the SampleTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref SampleTable
+      Environment:
+        Variables:
+          # Make table name accessible as environment variable from function code during execution
+          SAMPLE_TABLE: !Ref SampleTable
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /
+            Method: GET
+  # Each Lambda function is defined by properties:
+  # https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+
+  # This is a Lambda function config associated with the source code: get-by-id.js
+  getByIdFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: src/handlers/get-by-id.getByIdHandler
+      Runtime: nodejs14.x
+      MemorySize: 128
+      Timeout: 60
+      Description: A simple example includes a HTTP get method to get one item by id from a DynamoDB table.
+      Policies:
+        # Give Create/Read/Update/Delete Permissions to the SampleTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref SampleTable
+      Environment:
+        Variables:
+          # Make table name accessible as environment variable from function code during execution
+          SAMPLE_TABLE: !Ref SampleTable
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /{id}
+            Method: GET
+  # Each Lambda function is defined by properties:
+  # https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+
+  # This is a Lambda function config associated with the source code: put-item.js
+  putItemFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: src/handlers/put-item.putItemHandler
+      Runtime: nodejs14.x
+      MemorySize: 128
+      Timeout: 60
+      Description: A simple example includes a HTTP post method to add one item to a DynamoDB table.
+      Policies:
+        # Give Create/Read/Update/Delete Permissions to the SampleTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref SampleTable
+      Environment:
+        Variables:
+          # Make table name accessible as environment variable from function code during execution
+          SAMPLE_TABLE: !Ref SampleTable
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /
+            Method: POST
+  # Simple syntax to create a DynamoDB table with a single attribute primary key, more in
+  # https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlesssimpletable
+
+  # DynamoDB table to store item: {id: <ID>, name: <NAME>}
+  SampleTable:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      PrimaryKey:
+        Name: id
+        Type: String
+      ProvisionedThroughput:
+        ReadCapacityUnits: 2
+        WriteCapacityUnits: 2


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* This adds sample apps in the `nodejs14.x` runtime to prepare for the upcoming [end of support date](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html#w310aac35c65c19) of `nodejs10.x`. They are added alongside the existing apps, rather than updating runtime references and the `nodejs10.x` folder path, since the existing apps are still referenced by other materials such as the AWS Lambda console.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
